### PR TITLE
Make GltfAssetWriterV2 thread-safe

### DIFF
--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/io/v2/GltfAssetWriterV2.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/io/v2/GltfAssetWriterV2.java
@@ -30,8 +30,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.IntBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 import java.util.Arrays;
@@ -167,17 +165,6 @@ public final class GltfAssetWriterV2
         private ByteArrayOutputStream baos;
         
         /**
-         * Temporary buffer for int value data
-         */
-        private static final byte[] INT_DATA = new byte[4];
-        
-        /**
-         * The buffer for filling the INT_DATA
-         */
-        private static final IntBuffer INT_BUFFER = ByteBuffer.wrap(INT_DATA)
-            .order(ByteOrder.LITTLE_ENDIAN).asIntBuffer();
-        
-        /**
          * Default constructor
          */
         ChunkData()
@@ -193,8 +180,10 @@ public final class GltfAssetWriterV2
          */
         void append(int value) throws IOException
         {
-            INT_BUFFER.put(0, value);
-            baos.write(INT_DATA);
+            baos.write((value >> 0) & 0xFF);
+            baos.write((value >> 8) & 0xFF);
+            baos.write((value >> 16) & 0xFF);
+            baos.write((value >> 24) & 0xFF);
         }
         
         /**


### PR DESCRIPTION
Fixes https://github.com/javagl/JglTF/issues/61 , hopefully.

There was a use of a static array in [GltfAssetWriter](https://github.com/javagl/JglTF/blob/6a94c5669a4e9bc8cbc704b22782718c7b3f4c89/jgltf-model/src/main/java/de/javagl/jgltf/model/io/v2/GltfAssetWriterV2.java#L172) that caused problems when using this class from multiple threads. The fact that there was a static mutable state (and that it was only a complicated way of reversing a byte order) is somewhat embarassing, but ... it should be fixed now. 

The "test" for this was already posted similarly in the issue, and is somewhat pragmatic: It just writes many dummy models with many threads, and then tries to read them back in. Before the change, this _reliably_ caused crashes when trying to read the data. (Suprisingly reliably - I started it several times, even with fewer models and fewer threads, and it _always_ crashed). After the change, I did not observe any crashes.

```
package de.javagl.jgltf.model.io.test;

import java.io.File;
import java.io.IOException;
import java.nio.FloatBuffer;
import java.nio.IntBuffer;
import java.nio.file.Files;
import java.nio.file.Path;
import java.nio.file.Paths;
import java.util.ArrayList;
import java.util.List;
import java.util.concurrent.ExecutorService;
import java.util.concurrent.LinkedBlockingQueue;
import java.util.concurrent.ThreadPoolExecutor;
import java.util.concurrent.TimeUnit;

import de.javagl.jgltf.model.GltfModel;
import de.javagl.jgltf.model.creation.GltfModelBuilder;
import de.javagl.jgltf.model.creation.MaterialBuilder;
import de.javagl.jgltf.model.creation.MeshPrimitiveBuilder;
import de.javagl.jgltf.model.impl.DefaultGltfModel;
import de.javagl.jgltf.model.impl.DefaultMeshModel;
import de.javagl.jgltf.model.impl.DefaultMeshPrimitiveModel;
import de.javagl.jgltf.model.impl.DefaultNodeModel;
import de.javagl.jgltf.model.impl.DefaultSceneModel;
import de.javagl.jgltf.model.io.GltfModelReader;
import de.javagl.jgltf.model.io.GltfModelWriter;
import de.javagl.jgltf.model.v2.MaterialModelV2;

public class MultiThreadedWriting
{
    public static void main(String[] args) throws Exception
    {
        int numModels = 150;
        int numThreads = 50;
        Path outputPath = Paths.get("./data/multiThreadedWriting");
        Files.createDirectories(outputPath);

        // Create a list of trivial models
        List<GltfModel> gltfModels = new ArrayList<GltfModel>();
        for (int i=0; i<numModels; i++)
        {
            GltfModel gltfModel = createGltfModel();
            gltfModels.add(gltfModel);
        }

        // Write the models on multiple threads, using the same writer
        GltfModelWriter gltfModelWriter = new GltfModelWriter();
        ExecutorService e = createExecutorService(numThreads);
        for (int i=0; i<numModels; i++)
        {
            GltfModel gltfModel = gltfModels.get(i);
            String outputFileName = "model-"+i+".glb";
            File outputFile = outputPath.resolve(outputFileName).toFile();
            Runnable task = () -> write(gltfModel, gltfModelWriter, outputFile);
            e.submit(task);
        }
        e.awaitTermination(3, TimeUnit.SECONDS);
        System.out.println("Done writing");
        
        testReading(outputPath, numModels);
        
    }
    
    private static void testReading(
        Path outputPath, int numModels) throws IOException
    {
        GltfModelReader gltfModelReader = new GltfModelReader();
        for (int i=0; i<numModels; i++)
        {
            String fileName = "model-"+i+".glb";
            File file = outputPath.resolve(fileName).toFile();
            GltfModel gltfModel = gltfModelReader.read(file.toURI());
            System.out.println("Read "+fileName+" to "+gltfModel);
        }
        System.out.println("Done reading");
        
    }
    
    private static ExecutorService createExecutorService(int poolSize)
    {
        long keepAliveTime = 1;
        TimeUnit timeUnit = TimeUnit.SECONDS;
        ThreadPoolExecutor e = 
            new ThreadPoolExecutor(poolSize, poolSize,
                keepAliveTime, timeUnit, new LinkedBlockingQueue<Runnable>());
        e.allowCoreThreadTimeOut(true);
        return e;
    }    
    
    private static void write(GltfModel gltfModel, 
        GltfModelWriter gltfModelWriter, File outputFile)
    {
        try
        {
            System.out.println(
                "Writing " + outputFile + " on " + Thread.currentThread());
            gltfModelWriter.writeBinary(gltfModel, outputFile);
        }
        catch (IOException e)
        {
            // Ignored here
            e.printStackTrace();
        }
    }

    private static GltfModel createGltfModel() 
    {
        // Create a mesh primitive
        int indices[] = { 0, 1, 2 };
        float positions[] =
        {
            0.0f, 0.0f, 0.0f,
            1.0f, 0.0f, 0.0f,
            0.5f, 1.0f, 0.0f
        };
        
        MeshPrimitiveBuilder meshPrimitiveBuilder = 
            MeshPrimitiveBuilder.create(); 
        meshPrimitiveBuilder.setIntIndicesAsShort(IntBuffer.wrap(indices));
        meshPrimitiveBuilder.addPositions3D(FloatBuffer.wrap(positions));
        DefaultMeshPrimitiveModel meshPrimitiveModel = 
            meshPrimitiveBuilder.build();
        
        // Create a material, and assign it to the mesh primitive
        MaterialBuilder materialBuilder =  MaterialBuilder.create();
        materialBuilder.setBaseColorFactor(1.0f, 0.9f, 0.9f, 1.0f);
        materialBuilder.setDoubleSided(true);
        MaterialModelV2 materialModel = materialBuilder.build();
        meshPrimitiveModel.setMaterialModel(materialModel);

        // Create a mesh with the mesh primitive
        DefaultMeshModel meshModel = new DefaultMeshModel();
        meshModel.addMeshPrimitiveModel(meshPrimitiveModel);

        // Create a node with the mesh
        DefaultNodeModel nodeModel = new DefaultNodeModel();
        nodeModel.addMeshModel(meshModel);
        
        // Create a scene with the node
        DefaultSceneModel sceneModel = new DefaultSceneModel();
        sceneModel.addNode(nodeModel);
        
        // Pass the scene to the model builder. It will take care
        // of the other model elements that are contained in the scene.
        // (I.e. the mesh primitive and its accessors, and the material 
        // and its textures)
        GltfModelBuilder gltfModelBuilder = GltfModelBuilder.create();
        gltfModelBuilder.addSceneModel(sceneModel);
        DefaultGltfModel gltfModel = gltfModelBuilder.build();

        return gltfModel;
    }
    
}
```
