### PR TITLE
Extensions- and Asset model

### DIFF
--- a/jgltf-browser/pom.xml
+++ b/jgltf-browser/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>de.javagl</groupId>
     <artifactId>jgltf-parent</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>jgltf-browser</artifactId>
@@ -51,32 +51,32 @@
     <dependency>
       <groupId>de.javagl</groupId>
       <artifactId>jgltf-impl-v1</artifactId>
-      <version>2.0.2-SNAPSHOT</version>
+      <version>2.0.4-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>de.javagl</groupId>
       <artifactId>jgltf-model</artifactId>
-      <version>2.0.2-SNAPSHOT</version>
+      <version>2.0.4-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>de.javagl</groupId>
       <artifactId>jgltf-obj</artifactId>
-      <version>2.0.2-SNAPSHOT</version>
+      <version>2.0.4-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>de.javagl</groupId>
       <artifactId>jgltf-viewer</artifactId>
-      <version>2.0.2-SNAPSHOT</version>
+      <version>2.0.4-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>de.javagl</groupId>
       <artifactId>jgltf-viewer-jogl</artifactId>
-      <version>2.0.2-SNAPSHOT</version>
+      <version>2.0.4-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>de.javagl</groupId>
       <artifactId>jgltf-viewer-lwjgl</artifactId>
-      <version>2.0.2-SNAPSHOT</version>
+      <version>2.0.4-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>de.javagl</groupId>

--- a/jgltf-impl-v2-ext-instance-features/pom.xml
+++ b/jgltf-impl-v2-ext-instance-features/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>de.javagl</groupId>
     <artifactId>jgltf-parent</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>jgltf-impl-v2-ext-instance-features</artifactId>
@@ -28,14 +28,14 @@
     <dependency>
       <groupId>de.javagl</groupId>
       <artifactId>jgltf-impl-v2</artifactId>
-      <version>2.0.2-SNAPSHOT</version>
+      <version>2.0.4-SNAPSHOT</version>
     </dependency>
 
     <!-- Only required for test! -->
     <dependency>
       <groupId>de.javagl</groupId>
       <artifactId>jgltf-model</artifactId>
-      <version>2.0.2-SNAPSHOT</version>
+      <version>2.0.4-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
 

--- a/jgltf-impl-v2-ext-mesh-features/pom.xml
+++ b/jgltf-impl-v2-ext-mesh-features/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>de.javagl</groupId>
     <artifactId>jgltf-parent</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>jgltf-impl-v2-ext-mesh-features</artifactId>
@@ -28,14 +28,14 @@
     <dependency>
       <groupId>de.javagl</groupId>
       <artifactId>jgltf-impl-v2</artifactId>
-      <version>2.0.2-SNAPSHOT</version>
+      <version>2.0.4-SNAPSHOT</version>
     </dependency>
 
     <!-- Only required for test! -->
     <dependency>
       <groupId>de.javagl</groupId>
       <artifactId>jgltf-model</artifactId>
-      <version>2.0.2-SNAPSHOT</version>
+      <version>2.0.4-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
 

--- a/jgltf-impl-v2-ext-mesh-gpu-instancing/pom.xml
+++ b/jgltf-impl-v2-ext-mesh-gpu-instancing/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>de.javagl</groupId>
     <artifactId>jgltf-parent</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>jgltf-impl-v2-ext-mesh-gpu-instancing</artifactId>
@@ -28,14 +28,14 @@
     <dependency>
       <groupId>de.javagl</groupId>
       <artifactId>jgltf-impl-v2</artifactId>
-      <version>2.0.2-SNAPSHOT</version>
+      <version>2.0.4-SNAPSHOT</version>
     </dependency>
 
     <!-- Only required for test! -->
     <dependency>
       <groupId>de.javagl</groupId>
       <artifactId>jgltf-model</artifactId>
-      <version>2.0.2-SNAPSHOT</version>
+      <version>2.0.4-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
 

--- a/jgltf-impl-v2-ext-structural-metadata/pom.xml
+++ b/jgltf-impl-v2-ext-structural-metadata/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>de.javagl</groupId>
     <artifactId>jgltf-parent</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>jgltf-impl-v2-ext-structural-metadata</artifactId>
@@ -28,14 +28,14 @@
     <dependency>
       <groupId>de.javagl</groupId>
       <artifactId>jgltf-impl-v2</artifactId>
-      <version>2.0.2-SNAPSHOT</version>
+      <version>2.0.4-SNAPSHOT</version>
     </dependency>
 
     <!-- Only required for test! -->
     <dependency>
       <groupId>de.javagl</groupId>
       <artifactId>jgltf-model</artifactId>
-      <version>2.0.2-SNAPSHOT</version>
+      <version>2.0.4-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
 

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/AssetModel.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/AssetModel.java
@@ -1,0 +1,54 @@
+/*
+ * www.javagl.de - JglTF
+ *
+ * Copyright 2015-2017 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jgltf.model;
+
+/**
+ * Interface for an asset. 
+ * 
+ * Note that this model does not include the version information that
+ * will eventually be written as the <code>gltf.asset.version</code>.
+ * This version information is <i>intentionally</i> hidden in the
+ * model, and will depend on the version in which the model will
+ * be written.
+ */
+public interface AssetModel extends NamedModelElement
+{
+    /**
+     * Returns the copyright message, suitable for display to credit
+     * the content creator.
+     * 
+     * @return The copyright message
+     */
+    String getCopyright();
+    
+    /**
+     * Returns the tool that generated this glTF model
+     * 
+     * @return The tool
+     */
+    String getGenerator();
+}

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/ExtensionsModel.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/ExtensionsModel.java
@@ -1,0 +1,56 @@
+/*
+ * www.javagl.de - JglTF
+ *
+ * Copyright 2015-2017 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jgltf.model;
+
+import java.util.List;
+
+/**
+ * An interface for the information about the extensions that are used in a
+ * {@link GltfModel}.
+ */
+public interface ExtensionsModel
+{
+    /**
+     * Returns the list of extension names that are declared as the
+     * <code>extensionsUsed</code> in the glTF asset.
+     * 
+     * The list should be assumed to be unmodifiable.
+     * 
+     * @return The list of used extensions
+     */
+    List<String> getExtensionsUsed();
+
+    /**
+     * Returns the list of extension names that are declared as the
+     * <code>extensionsRequired</code> in the glTF asset.
+     * 
+     * The list should be assumed to be unmodifiable.
+     * 
+     * @return The list of required extensions
+     */
+    List<String> getExtensionsRequired();
+}

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/GltfModel.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/GltfModel.java
@@ -137,5 +137,13 @@ public interface GltfModel extends ModelElement
      */
     ExtensionsModel getExtensionsModel();
     
+    /**
+     * Returns the {@link AssetModel} that contains information
+     * about the asset that is represented with this model.
+     * 
+     * @return The {@link AssetModel}
+     */
+    AssetModel getAssetModel();
+    
 }
 

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/GltfModel.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/GltfModel.java
@@ -129,5 +129,13 @@ public interface GltfModel extends ModelElement
      */
     List<TextureModel> getTextureModels();
     
+    /**
+     * Returns the {@link ExtensionsModel} that summarizes information
+     * about the extensions that are used in the glTF.
+     * 
+     * @return The {@link ExtensionsModel}
+     */
+    ExtensionsModel getExtensionsModel();
+    
 }
 

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/impl/DefaultAssetModel.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/impl/DefaultAssetModel.java
@@ -1,0 +1,78 @@
+/*
+ * www.javagl.de - JglTF
+ *
+ * Copyright 2015-2017 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jgltf.model.impl;
+
+import de.javagl.jgltf.model.AssetModel;
+
+/**
+ * Default implementation of an {@link AssetModel}
+ */
+public class DefaultAssetModel extends AbstractNamedModelElement
+    implements AssetModel
+{
+    /**
+     * The copyright
+     */
+    private String copyright;
+
+    /**
+     * The generator
+     */
+    private String generator;
+
+    /**
+     * Set the copyright
+     * 
+     * @param copyright The copyright
+     */
+    public void setCopyright(String copyright)
+    {
+        this.copyright = copyright;
+    }
+
+    @Override
+    public String getCopyright()
+    {
+        return copyright;
+    }
+
+    /**
+     * Set the generator
+     * 
+     * @param generator The generator
+     */
+    public void setGenerator(String generator)
+    {
+        this.generator = generator;
+    }
+
+    @Override
+    public String getGenerator()
+    {
+        return generator;
+    }
+}

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/impl/DefaultExtensionsModel.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/impl/DefaultExtensionsModel.java
@@ -1,0 +1,186 @@
+/*
+ * www.javagl.de - JglTF
+ *
+ * Copyright 2015-2017 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jgltf.model.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import de.javagl.jgltf.model.ExtensionsModel;
+
+/**
+ * Default implementation of an {@link ExtensionsModel}.
+ * 
+ * This implementation ensures a certain degree of consistency for
+ * the extension information:
+ * <ul>
+ *   <li>
+ *     The extension names will always be unique
+ *   </li>
+ *   <li>
+ *     Adding an extension as "required" will also add it as "used"
+ *   </li>
+ *   <li>
+ *     Removing an extension as "used" will also remove it as "required"
+ *   </li>
+ * </ul>
+ * (Of course, adding a "used" extension will not add it as a "required" one,
+ * and <i>removing</i> a "required" extension will <i>not</i> remove it as 
+ * a "used" extension) 
+ */
+public class DefaultExtensionsModel implements ExtensionsModel
+{
+    /**
+     * The used extensions
+     */
+    private final Set<String> extensionsUsed;
+
+    /**
+     * The required extensions
+     */
+    private final Set<String> extensionsRequired;
+
+    /**
+     * Default constructor
+     */
+    public DefaultExtensionsModel()
+    {
+        this.extensionsUsed = new LinkedHashSet<String>();
+        this.extensionsRequired = new LinkedHashSet<String>();
+    }
+
+    /**
+     * Add the given extension name to the "used" extensions.
+     * 
+     * @param extension The extension name.
+     */
+    public void addExtensionUsed(String extension)
+    {
+        this.extensionsUsed.add(extension);
+    }
+
+    /**
+     * Remove the given extension name from the "used" extensions and
+     * from the list of "required" extensions.
+     * 
+     * @param extension The extension name.
+     */
+    public void removeExtensionUsed(String extension)
+    {
+        this.extensionsUsed.remove(extension);
+        removeExtensionRequired(extension);
+    }
+
+    /**
+     * Add the given extension names to the "used" extensions.
+     * 
+     * @param extensions The extension names
+     */
+    public void addExtensionsUsed(Collection<String> extensions)
+    {
+        if (extensions != null) 
+        {
+            this.extensionsUsed.addAll(extensions);
+        }
+    }
+
+    /**
+     * Clear the list of "used" extensions and the list of "required" extensions
+     */
+    public void clearExtensionUsed()
+    {
+        this.extensionsUsed.clear();
+        clearExtensionRequired();
+    }
+
+    @Override
+    public List<String> getExtensionsUsed()
+    {
+        return Collections.unmodifiableList(
+            new ArrayList<String>(extensionsUsed));
+    }
+
+    
+    /**
+     * Add the given extension name to the "required" extensions and to
+     * the "used" extensions.
+     * 
+     * @param extension The extension name.
+     */
+    public void addExtensionRequired(String extension)
+    {
+        this.extensionsRequired.add(extension);
+        addExtensionUsed(extension);
+    }
+
+    /**
+     * Remove the given extension name from the "required" extensions.
+     * 
+     * (Note that this will <i>not</i> remove the given extension name
+     * from the "used" extensions!)
+     * 
+     * @param extension The extension name.
+     */
+    public void removeExtensionRequired(String extension)
+    {
+        this.extensionsRequired.remove(extension);
+    }
+
+    /**
+     * Add the given extension names to the "required" extensions and to
+     * the "used" extensions.
+     * 
+     * @param extensions The extension names
+     */
+    public void addExtensionsRequired(Collection<String> extensions)
+    {
+        if (extensions != null)
+        {
+            this.extensionsRequired.addAll(extensions);
+            addExtensionsUsed(extensions);
+        }
+    }
+
+    /**
+     * Clear the list of "required" extensions.
+     */
+    public void clearExtensionRequired()
+    {
+        this.extensionsRequired.clear();
+    }
+    
+    @Override
+    public List<String> getExtensionsRequired()
+    {
+        return Collections.unmodifiableList(
+            new ArrayList<String>(extensionsRequired));
+    }
+
+}

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/impl/DefaultGltfModel.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/impl/DefaultGltfModel.java
@@ -33,6 +33,7 @@ import java.util.List;
 
 import de.javagl.jgltf.model.AccessorModel;
 import de.javagl.jgltf.model.AnimationModel;
+import de.javagl.jgltf.model.AssetModel;
 import de.javagl.jgltf.model.BufferModel;
 import de.javagl.jgltf.model.BufferViewModel;
 import de.javagl.jgltf.model.CameraModel;
@@ -115,6 +116,11 @@ public class DefaultGltfModel extends AbstractModelElement implements GltfModel
      * The {@link ExtensionsModel}
      */
     private final DefaultExtensionsModel extensionsModel;
+    
+    /**
+     * The {@link AssetModel}
+     */
+    private final DefaultAssetModel assetModel;
 
     /**
      * Creates a new model 
@@ -134,6 +140,7 @@ public class DefaultGltfModel extends AbstractModelElement implements GltfModel
         this.skinModels = new ArrayList<DefaultSkinModel>();
         this.textureModels = new ArrayList<DefaultTextureModel>();
         this.extensionsModel = new DefaultExtensionsModel();
+        this.assetModel = new DefaultAssetModel();
     }
     
     /**
@@ -848,5 +855,11 @@ public class DefaultGltfModel extends AbstractModelElement implements GltfModel
     public DefaultExtensionsModel getExtensionsModel()
     {
         return extensionsModel;
+    }
+    
+    @Override
+    public DefaultAssetModel getAssetModel()
+    {
+        return assetModel;
     }
 }

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/impl/DefaultGltfModel.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/impl/DefaultGltfModel.java
@@ -36,6 +36,7 @@ import de.javagl.jgltf.model.AnimationModel;
 import de.javagl.jgltf.model.BufferModel;
 import de.javagl.jgltf.model.BufferViewModel;
 import de.javagl.jgltf.model.CameraModel;
+import de.javagl.jgltf.model.ExtensionsModel;
 import de.javagl.jgltf.model.GltfModel;
 import de.javagl.jgltf.model.ImageModel;
 import de.javagl.jgltf.model.MaterialModel;
@@ -109,6 +110,11 @@ public class DefaultGltfModel extends AbstractModelElement implements GltfModel
      * The {@link TextureModel} instances
      */
     private final List<DefaultTextureModel> textureModels;
+    
+    /**
+     * The {@link ExtensionsModel}
+     */
+    private final DefaultExtensionsModel extensionsModel;
 
     /**
      * Creates a new model 
@@ -127,6 +133,7 @@ public class DefaultGltfModel extends AbstractModelElement implements GltfModel
         this.sceneModels = new ArrayList<DefaultSceneModel>();
         this.skinModels = new ArrayList<DefaultSkinModel>();
         this.textureModels = new ArrayList<DefaultTextureModel>();
+        this.extensionsModel = new DefaultExtensionsModel();
     }
     
     /**
@@ -835,5 +842,11 @@ public class DefaultGltfModel extends AbstractModelElement implements GltfModel
     public List<TextureModel> getTextureModels()
     {
         return Collections.unmodifiableList(textureModels);
+    }
+    
+    @Override
+    public DefaultExtensionsModel getExtensionsModel()
+    {
+        return extensionsModel;
     }
 }

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/v1/GltfCreatorV1.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/v1/GltfCreatorV1.java
@@ -72,6 +72,7 @@ import de.javagl.jgltf.model.AccessorModel;
 import de.javagl.jgltf.model.AnimationModel;
 import de.javagl.jgltf.model.AnimationModel.Channel;
 import de.javagl.jgltf.model.AnimationModel.Sampler;
+import de.javagl.jgltf.model.AssetModel;
 import de.javagl.jgltf.model.BufferModel;
 import de.javagl.jgltf.model.BufferViewModel;
 import de.javagl.jgltf.model.CameraModel;
@@ -383,17 +384,16 @@ public class GltfCreatorV1
             gltf.setScene(gltf.getScenes().keySet().iterator().next());
         }
         
-        Asset asset = new Asset();
-        asset.setVersion("1.0");
-        asset.setGenerator("JglTF from https://github.com/javagl/JglTF");
-        gltf.setAsset(asset);
-        
         ExtensionsModel extensionsModel = gltfModel.getExtensionsModel();
         List<String> extensionsUsed = extensionsModel.getExtensionsUsed();
         if (!extensionsUsed.isEmpty()) 
         {
             gltf.setExtensionsUsed(extensionsUsed);
         }
+        
+        Asset asset = createAsset(gltfModel.getAssetModel());
+        gltf.setAsset(asset);
+        
         return gltf;
     }
     
@@ -1115,6 +1115,31 @@ public class GltfCreatorV1
         texture.setSource(imageIds.get(textureModel.getImageModel()));
         
         return texture;
+    }
+    
+    /**
+     * Creates an asset for the given {@link AssetModel}
+     * 
+     * @param assetModel The {@link AssetModel}
+     * @return The {@link Asset}
+     */
+    private Asset createAsset(AssetModel assetModel)
+    {
+        Asset asset = new Asset();
+        asset.setVersion("1.0");
+        asset.setGenerator("JglTF from https://github.com/javagl/JglTF");
+        
+        transferGltfPropertyElements(assetModel, asset);
+        
+        if (assetModel.getCopyright() != null)
+        {
+            asset.setCopyright(assetModel.getCopyright());
+        }
+        if (assetModel.getGenerator() != null)
+        {
+            asset.setGenerator(assetModel.getGenerator());
+        }
+        return asset;
     }
 
     /**

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/v1/GltfCreatorV1.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/v1/GltfCreatorV1.java
@@ -77,6 +77,7 @@ import de.javagl.jgltf.model.BufferViewModel;
 import de.javagl.jgltf.model.CameraModel;
 import de.javagl.jgltf.model.CameraOrthographicModel;
 import de.javagl.jgltf.model.CameraPerspectiveModel;
+import de.javagl.jgltf.model.ExtensionsModel;
 import de.javagl.jgltf.model.GltfConstants;
 import de.javagl.jgltf.model.GltfModel;
 import de.javagl.jgltf.model.ImageModel;
@@ -387,6 +388,12 @@ public class GltfCreatorV1
         asset.setGenerator("JglTF from https://github.com/javagl/JglTF");
         gltf.setAsset(asset);
         
+        ExtensionsModel extensionsModel = gltfModel.getExtensionsModel();
+        List<String> extensionsUsed = extensionsModel.getExtensionsUsed();
+        if (!extensionsUsed.isEmpty()) 
+        {
+            gltf.setExtensionsUsed(extensionsUsed);
+        }
         return gltf;
     }
     

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/v1/GltfModelCreatorV1.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/v1/GltfModelCreatorV1.java
@@ -42,6 +42,7 @@ import de.javagl.jgltf.impl.v1.Animation;
 import de.javagl.jgltf.impl.v1.AnimationChannel;
 import de.javagl.jgltf.impl.v1.AnimationChannelTarget;
 import de.javagl.jgltf.impl.v1.AnimationSampler;
+import de.javagl.jgltf.impl.v1.Asset;
 import de.javagl.jgltf.impl.v1.Buffer;
 import de.javagl.jgltf.impl.v1.BufferView;
 import de.javagl.jgltf.impl.v1.Camera;
@@ -71,6 +72,7 @@ import de.javagl.jgltf.model.Accessors;
 import de.javagl.jgltf.model.AnimationModel;
 import de.javagl.jgltf.model.AnimationModel.Channel;
 import de.javagl.jgltf.model.AnimationModel.Interpolation;
+import de.javagl.jgltf.model.AssetModel;
 import de.javagl.jgltf.model.BufferModel;
 import de.javagl.jgltf.model.BufferViewModel;
 import de.javagl.jgltf.model.CameraModel;
@@ -105,6 +107,7 @@ import de.javagl.jgltf.model.impl.DefaultAccessorModel;
 import de.javagl.jgltf.model.impl.DefaultAnimationModel;
 import de.javagl.jgltf.model.impl.DefaultAnimationModel.DefaultChannel;
 import de.javagl.jgltf.model.impl.DefaultAnimationModel.DefaultSampler;
+import de.javagl.jgltf.model.impl.DefaultAssetModel;
 import de.javagl.jgltf.model.impl.DefaultBufferModel;
 import de.javagl.jgltf.model.impl.DefaultBufferViewModel;
 import de.javagl.jgltf.model.impl.DefaultCameraModel;
@@ -234,6 +237,7 @@ public class GltfModelCreatorV1
         initProgramModels();
         
         initExtensionsModel();
+        initAssetModel();
     }
     
     /**
@@ -1426,6 +1430,23 @@ public class GltfModelCreatorV1
         DefaultExtensionsModel extensionsModel = gltfModel.getExtensionsModel();
         extensionsModel.addExtensionsUsed(extensionsUsed);
     }
+    
+    /**
+     * Initialize the {@link AssetModel} with the asset information that
+     * was given in the glTF.
+     */
+    private void initAssetModel() 
+    {
+        Asset asset = gltf.getAsset();
+        if (asset != null)
+        {
+            DefaultAssetModel assetModel = gltfModel.getAssetModel();
+            transferGltfPropertyElements(asset, assetModel);
+            assetModel.setCopyright(asset.getCopyright());
+            assetModel.setGenerator(asset.getGenerator());
+        }
+    }
+    
     
     /**
      * Transfer the extensions and extras from the given property to

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/v1/GltfModelCreatorV1.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/v1/GltfModelCreatorV1.java
@@ -75,6 +75,7 @@ import de.javagl.jgltf.model.BufferModel;
 import de.javagl.jgltf.model.BufferViewModel;
 import de.javagl.jgltf.model.CameraModel;
 import de.javagl.jgltf.model.ElementType;
+import de.javagl.jgltf.model.ExtensionsModel;
 import de.javagl.jgltf.model.GltfConstants;
 import de.javagl.jgltf.model.GltfModel;
 import de.javagl.jgltf.model.ImageModel;
@@ -109,6 +110,7 @@ import de.javagl.jgltf.model.impl.DefaultBufferViewModel;
 import de.javagl.jgltf.model.impl.DefaultCameraModel;
 import de.javagl.jgltf.model.impl.DefaultCameraOrthographicModel;
 import de.javagl.jgltf.model.impl.DefaultCameraPerspectiveModel;
+import de.javagl.jgltf.model.impl.DefaultExtensionsModel;
 import de.javagl.jgltf.model.impl.DefaultGltfModel;
 import de.javagl.jgltf.model.impl.DefaultImageModel;
 import de.javagl.jgltf.model.impl.DefaultMeshModel;
@@ -129,13 +131,28 @@ import de.javagl.jgltf.model.v1.gl.TechniqueStatesFunctionsModels;
  * A class that is responsible for filling a {@link DefaultGltfModel} with
  * the model instances that are created from a {@link GltfAssetV1}
  */
-class GltfModelCreatorV1
+public class GltfModelCreatorV1
 {
     /**
      * The logger used in this class
      */
     private static final Logger logger = 
         Logger.getLogger(GltfModelCreatorV1.class.getName());
+    
+    /**
+     * Create the {@link GltfModel} for the given {@link GltfAssetV1}
+     * 
+     * @param gltfAsset The {@link GltfAssetV1}
+     * @return The {@link GltfModel}
+     */
+    public static GltfModelV1 create(GltfAssetV1 gltfAsset)
+    {
+        GltfModelV1 gltfModel = new GltfModelV1();
+        GltfModelCreatorV1 creator = 
+            new GltfModelCreatorV1(gltfAsset, gltfModel);
+        creator.create();
+        return gltfModel;
+    }
     
     /**
      * The {@link IndexMappingSet}
@@ -215,6 +232,8 @@ class GltfModelCreatorV1
         initTextureModels();
         initShaderModels();
         initProgramModels();
+        
+        initExtensionsModel();
     }
     
     /**
@@ -1394,6 +1413,18 @@ class GltfModelCreatorV1
             }
             materialModel.setValues(modelValues);
         }
+    }
+    
+    /**
+     * Initialize the {@link ExtensionsModel} with the extensions that
+     * are used in the glTF.
+     */
+    private void initExtensionsModel() 
+    {
+        // Note that glTF 1.0 only had 'extensionsUsed', no 'extensionsRequired'
+        List<String> extensionsUsed = gltf.getExtensionsUsed();
+        DefaultExtensionsModel extensionsModel = gltfModel.getExtensionsModel();
+        extensionsModel.addExtensionsUsed(extensionsUsed);
     }
     
     /**

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfCreatorV2.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfCreatorV2.java
@@ -74,6 +74,7 @@ import de.javagl.jgltf.model.BufferViewModel;
 import de.javagl.jgltf.model.CameraModel;
 import de.javagl.jgltf.model.CameraOrthographicModel;
 import de.javagl.jgltf.model.CameraPerspectiveModel;
+import de.javagl.jgltf.model.ExtensionsModel;
 import de.javagl.jgltf.model.GltfModel;
 import de.javagl.jgltf.model.ImageModel;
 import de.javagl.jgltf.model.MaterialModel;
@@ -317,6 +318,19 @@ public class GltfCreatorV2
         asset.setVersion("2.0");
         asset.setGenerator("JglTF from https://github.com/javagl/JglTF");
         gltf.setAsset(asset);
+        
+        ExtensionsModel extensionsModel = gltfModel.getExtensionsModel();
+        List<String> extensionsUsed = extensionsModel.getExtensionsUsed();
+        if (!extensionsUsed.isEmpty()) 
+        {
+            gltf.setExtensionsUsed(extensionsUsed);
+        }
+        List<String> extensionsRequired = 
+            extensionsModel.getExtensionsRequired();
+        if (!extensionsRequired.isEmpty()) 
+        {
+            gltf.setExtensionsRequired(extensionsRequired);
+        }
         
         return gltf;
     }

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfCreatorV2.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfCreatorV2.java
@@ -67,6 +67,7 @@ import de.javagl.jgltf.model.AccessorData;
 import de.javagl.jgltf.model.AccessorDatas;
 import de.javagl.jgltf.model.AccessorModel;
 import de.javagl.jgltf.model.AnimationModel;
+import de.javagl.jgltf.model.AssetModel;
 import de.javagl.jgltf.model.AnimationModel.Channel;
 import de.javagl.jgltf.model.AnimationModel.Sampler;
 import de.javagl.jgltf.model.BufferModel;
@@ -314,11 +315,6 @@ public class GltfCreatorV2
             gltf.setScene(0);
         }
         
-        Asset asset = new Asset();
-        asset.setVersion("2.0");
-        asset.setGenerator("JglTF from https://github.com/javagl/JglTF");
-        gltf.setAsset(asset);
-        
         ExtensionsModel extensionsModel = gltfModel.getExtensionsModel();
         List<String> extensionsUsed = extensionsModel.getExtensionsUsed();
         if (!extensionsUsed.isEmpty()) 
@@ -331,6 +327,9 @@ public class GltfCreatorV2
         {
             gltf.setExtensionsRequired(extensionsRequired);
         }
+        
+        Asset asset = createAsset(gltfModel.getAssetModel());
+        gltf.setAsset(asset);
         
         return gltf;
     }
@@ -965,6 +964,31 @@ public class GltfCreatorV2
         texture.setSource(imageIndices.get(textureModel.getImageModel()));
         
         return texture;
+    }
+    
+    /**
+     * Creates an asset for the given {@link AssetModel}
+     * 
+     * @param assetModel The {@link AssetModel}
+     * @return The {@link Asset}
+     */
+    private Asset createAsset(AssetModel assetModel)
+    {
+        Asset asset = new Asset();
+        asset.setVersion("2.0");
+        asset.setGenerator("JglTF from https://github.com/javagl/JglTF");
+        
+        transferGltfPropertyElements(assetModel, asset);
+        
+        if (assetModel.getCopyright() != null)
+        {
+            asset.setCopyright(assetModel.getCopyright());
+        }
+        if (assetModel.getGenerator() != null)
+        {
+            asset.setGenerator(assetModel.getGenerator());
+        }
+        return asset;
     }
     
     /**

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfModelCreatorV2.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfModelCreatorV2.java
@@ -38,6 +38,7 @@ import java.util.logging.Logger;
 
 import de.javagl.jgltf.impl.v2.GlTFChildOfRootProperty;
 import de.javagl.jgltf.impl.v2.GlTFProperty;
+import de.javagl.jgltf.impl.v2.Asset;
 import de.javagl.jgltf.impl.v2.Accessor;
 import de.javagl.jgltf.impl.v2.AccessorSparse;
 import de.javagl.jgltf.impl.v2.AccessorSparseIndices;
@@ -69,6 +70,7 @@ import de.javagl.jgltf.model.AccessorData;
 import de.javagl.jgltf.model.AccessorDatas;
 import de.javagl.jgltf.model.AccessorModel;
 import de.javagl.jgltf.model.AnimationModel;
+import de.javagl.jgltf.model.AssetModel;
 import de.javagl.jgltf.model.AnimationModel.Channel;
 import de.javagl.jgltf.model.AnimationModel.Interpolation;
 import de.javagl.jgltf.model.BufferModel;
@@ -91,6 +93,7 @@ import de.javagl.jgltf.model.impl.AbstractModelElement;
 import de.javagl.jgltf.model.impl.AbstractNamedModelElement;
 import de.javagl.jgltf.model.impl.DefaultAccessorModel;
 import de.javagl.jgltf.model.impl.DefaultAnimationModel;
+import de.javagl.jgltf.model.impl.DefaultAssetModel;
 import de.javagl.jgltf.model.impl.DefaultAnimationModel.DefaultChannel;
 import de.javagl.jgltf.model.impl.DefaultAnimationModel.DefaultSampler;
 import de.javagl.jgltf.model.impl.DefaultBufferModel;
@@ -205,6 +208,7 @@ public class GltfModelCreatorV2
         initMaterialModels();
         
         initExtensionsModel();
+        initAssetModel();
     }
     
     /**
@@ -1279,6 +1283,22 @@ public class GltfModelCreatorV2
         extensionsModel.addExtensionsRequired(extensionsRequired);
     }
 
+    /**
+     * Initialize the {@link AssetModel} with the asset information that
+     * was given in the glTF.
+     */
+    private void initAssetModel() 
+    {
+        Asset asset = gltf.getAsset();
+        if (asset != null)
+        {
+            DefaultAssetModel assetModel = gltfModel.getAssetModel();
+            transferGltfPropertyElements(asset, assetModel);
+            assetModel.setCopyright(asset.getCopyright());
+            assetModel.setGenerator(asset.getGenerator());
+        }
+    }
+    
     /**
      * Transfer the extensions and extras from the given property to
      * the given target

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfModelCreatorV2.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfModelCreatorV2.java
@@ -75,6 +75,7 @@ import de.javagl.jgltf.model.BufferModel;
 import de.javagl.jgltf.model.BufferViewModel;
 import de.javagl.jgltf.model.CameraModel;
 import de.javagl.jgltf.model.ElementType;
+import de.javagl.jgltf.model.ExtensionsModel;
 import de.javagl.jgltf.model.GltfConstants;
 import de.javagl.jgltf.model.GltfModel;
 import de.javagl.jgltf.model.ImageModel;
@@ -97,6 +98,7 @@ import de.javagl.jgltf.model.impl.DefaultBufferViewModel;
 import de.javagl.jgltf.model.impl.DefaultCameraModel;
 import de.javagl.jgltf.model.impl.DefaultCameraOrthographicModel;
 import de.javagl.jgltf.model.impl.DefaultCameraPerspectiveModel;
+import de.javagl.jgltf.model.impl.DefaultExtensionsModel;
 import de.javagl.jgltf.model.impl.DefaultGltfModel;
 import de.javagl.jgltf.model.impl.DefaultImageModel;
 import de.javagl.jgltf.model.impl.DefaultMeshModel;
@@ -201,6 +203,8 @@ public class GltfModelCreatorV2
         initSkinModels();
         initTextureModels();
         initMaterialModels();
+        
+        initExtensionsModel();
     }
     
     /**
@@ -1260,6 +1264,19 @@ public class GltfModelCreatorV2
             material.getEmissiveFactor(),
             material.defaultEmissiveFactor());
         materialModel.setEmissiveFactor(emissiveFactor);
+    }
+    
+    /**
+     * Initialize the {@link ExtensionsModel} with the extensions that
+     * are used or required in the glTF.
+     */
+    private void initExtensionsModel() 
+    {
+        List<String> extensionsUsed = gltf.getExtensionsUsed();
+        List<String> extensionsRequired = gltf.getExtensionsRequired();
+        DefaultExtensionsModel extensionsModel = gltfModel.getExtensionsModel();
+        extensionsModel.addExtensionsUsed(extensionsUsed);
+        extensionsModel.addExtensionsRequired(extensionsRequired);
     }
 
     /**

--- a/jgltf-model/src/test/java/de/javagl/jgltf/model/TestAssetModelV1.java
+++ b/jgltf-model/src/test/java/de/javagl/jgltf/model/TestAssetModelV1.java
@@ -1,0 +1,110 @@
+/*
+ * www.javagl.de - JglTF
+ *
+ * Copyright 2015-2020 Marco Hutter - http://www.javagl.de
+ */
+package de.javagl.jgltf.model;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import de.javagl.jgltf.impl.v1.Asset;
+import de.javagl.jgltf.impl.v1.GlTF;
+import de.javagl.jgltf.model.impl.DefaultGltfModel;
+import de.javagl.jgltf.model.io.v1.GltfAssetV1;
+import de.javagl.jgltf.model.v1.GltfCreatorV1;
+import de.javagl.jgltf.model.v1.GltfModelCreatorV1;
+
+/**
+ * Tests for the basic handling of the {@link AssetModel} for glTF 1.0
+ */
+@SuppressWarnings("javadoc")
+public class TestAssetModelV1
+{
+    @Test
+    public void testAssetRoundtripV1() throws IOException
+    {
+        Map<String, Object> extras = new LinkedHashMap<String, Object>();
+        extras.put("extrasKey0", "extrasValue0");
+
+        Map<String, Object> extensions = new LinkedHashMap<String, Object>();
+        extensions.put("extensionsKey0", "extensionsValue0");
+
+        GlTF inputGltf = new GlTF();
+        Asset inputAsset = new Asset();
+        inputAsset.setExtras(extras);
+        inputAsset.setExtensions(extensions);
+        inputAsset.setCopyright("testCopyright");
+        inputAsset.setGenerator("testGenerator");
+        // The input version will be ignored. The result will be version 1.0.
+        inputAsset.setVersion("NOT_USED");
+        inputGltf.setAsset(inputAsset);
+
+        DefaultGltfModel gltfModel =
+            GltfModelCreatorV1.create(new GltfAssetV1(inputGltf, null));
+
+        GlTF outputGltf = GltfCreatorV1.create(gltfModel);
+        Asset outputAsset = outputGltf.getAsset();
+        assertEquals(inputAsset.getExtras(), outputAsset.getExtras());
+        assertEquals(inputAsset.getExtensions(), outputAsset.getExtensions());
+        assertEquals(inputAsset.getGenerator(), outputAsset.getGenerator());
+        assertEquals(inputAsset.getCopyright(), outputAsset.getCopyright());
+        assertEquals("1.0", outputAsset.getVersion());
+    }
+
+    @Test
+    public void testAssetDefaultV1() throws IOException
+    {
+        GlTF inputGltf = new GlTF();
+        Asset inputAsset = new Asset();
+        inputGltf.setAsset(inputAsset);
+
+        DefaultGltfModel gltfModel =
+            GltfModelCreatorV1.create(new GltfAssetV1(inputGltf, null));
+
+        GlTF outputGltf = GltfCreatorV1.create(gltfModel);
+        Asset outputAsset = outputGltf.getAsset();
+        assertEquals(inputAsset.getExtras(), outputAsset.getExtras());
+        assertEquals(inputAsset.getExtensions(), outputAsset.getExtensions());
+        assertEquals(inputAsset.getCopyright(), outputAsset.getCopyright());
+
+        String expectedGenerator = "JglTF from https://github.com/javagl/JglTF";
+        assertEquals(expectedGenerator, outputAsset.getGenerator());
+        assertEquals("1.0", outputAsset.getVersion());
+    }
+
+    @Test
+    public void testAssetModificationV1() throws IOException
+    {
+        GlTF inputGltf = new GlTF();
+        Asset inputAsset = new Asset();
+        inputGltf.setAsset(inputAsset);
+
+        DefaultGltfModel gltfModel =
+            GltfModelCreatorV1.create(new GltfAssetV1(inputGltf, null));
+
+        String expectedCopyright = "testCopyright";
+        gltfModel.getAssetModel().setCopyright(expectedCopyright);
+
+        Map<String, Object> expectedExtensions =
+            new LinkedHashMap<String, Object>();
+        expectedExtensions.put("testExtension", "testExtensionValue");
+        gltfModel.getAssetModel().setExtensions(expectedExtensions);
+
+        GlTF outputGltf = GltfCreatorV1.create(gltfModel);
+        Asset outputAsset = outputGltf.getAsset();
+        assertEquals(inputAsset.getExtras(), outputAsset.getExtras());
+        assertEquals(expectedExtensions, outputAsset.getExtensions());
+        assertEquals(expectedCopyright, outputAsset.getCopyright());
+
+        String expectedGenerator = "JglTF from https://github.com/javagl/JglTF";
+        assertEquals(expectedGenerator, outputAsset.getGenerator());
+        assertEquals("1.0", outputAsset.getVersion());
+    }
+
+}

--- a/jgltf-model/src/test/java/de/javagl/jgltf/model/TestAssetModelV2.java
+++ b/jgltf-model/src/test/java/de/javagl/jgltf/model/TestAssetModelV2.java
@@ -1,0 +1,111 @@
+/*
+ * www.javagl.de - JglTF
+ *
+ * Copyright 2015-2020 Marco Hutter - http://www.javagl.de
+ */
+package de.javagl.jgltf.model;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import de.javagl.jgltf.impl.v2.Asset;
+import de.javagl.jgltf.impl.v2.GlTF;
+import de.javagl.jgltf.model.impl.DefaultGltfModel;
+import de.javagl.jgltf.model.io.v2.GltfAssetV2;
+import de.javagl.jgltf.model.v2.GltfCreatorV2;
+import de.javagl.jgltf.model.v2.GltfModelCreatorV2;
+
+/**
+ * Tests for the basic handling of the {@link AssetModel} for glTF 2.0
+ */
+@SuppressWarnings("javadoc")
+public class TestAssetModelV2
+{
+    @Test
+    public void testAssetRoundtripV2() throws IOException
+    {
+        Map<String, Object> extras = new LinkedHashMap<String, Object>();
+        extras.put("extrasKey0", "extrasValue0");
+        
+        Map<String, Object> extensions = new LinkedHashMap<String, Object>();
+        extensions.put("extensionsKey0", "extensionsValue0");
+        
+        GlTF inputGltf = new GlTF();
+        Asset inputAsset = new Asset();
+        inputAsset.setExtras(extras);
+        inputAsset.setExtensions(extensions);
+        inputAsset.setCopyright("testCopyright");
+        inputAsset.setGenerator("testGenerator");
+        // The input version will be ignored. The result will be version 2.0.
+        inputAsset.setVersion("NOT_USED"); 
+        inputGltf.setAsset(inputAsset);
+
+        DefaultGltfModel gltfModel =
+            GltfModelCreatorV2.create(new GltfAssetV2(inputGltf, null));
+
+        GlTF outputGltf = GltfCreatorV2.create(gltfModel);
+        Asset outputAsset = outputGltf.getAsset();
+        assertEquals(inputAsset.getExtras(), outputAsset.getExtras());
+        assertEquals(inputAsset.getExtensions(), outputAsset.getExtensions());
+        assertEquals(inputAsset.getGenerator(), outputAsset.getGenerator());
+        assertEquals(inputAsset.getCopyright(), outputAsset.getCopyright());
+        assertEquals("2.0", outputAsset.getVersion());
+    }
+    
+    @Test
+    public void testAssetDefaultV2() throws IOException
+    {
+        GlTF inputGltf = new GlTF();
+        Asset inputAsset = new Asset();
+        inputGltf.setAsset(inputAsset);
+
+        DefaultGltfModel gltfModel =
+            GltfModelCreatorV2.create(new GltfAssetV2(inputGltf, null));
+
+        GlTF outputGltf = GltfCreatorV2.create(gltfModel);
+        Asset outputAsset = outputGltf.getAsset();
+        assertEquals(inputAsset.getExtras(), outputAsset.getExtras());
+        assertEquals(inputAsset.getExtensions(), outputAsset.getExtensions());
+        assertEquals(inputAsset.getCopyright(), outputAsset.getCopyright());
+        
+        String expectedGenerator = "JglTF from https://github.com/javagl/JglTF";
+        assertEquals(expectedGenerator, outputAsset.getGenerator());
+        assertEquals("2.0", outputAsset.getVersion());
+    }
+    
+    @Test
+    public void testAssetModificationV2() throws IOException
+    {
+        GlTF inputGltf = new GlTF();
+        Asset inputAsset = new Asset();
+        inputGltf.setAsset(inputAsset);
+
+        DefaultGltfModel gltfModel =
+            GltfModelCreatorV2.create(new GltfAssetV2(inputGltf, null));
+
+        String expectedCopyright = "testCopyright";
+        gltfModel.getAssetModel().setCopyright(expectedCopyright);
+
+        Map<String, Object> expectedExtensions =
+            new LinkedHashMap<String, Object>();
+        expectedExtensions.put("testExtension", "testExtensionValue");
+        gltfModel.getAssetModel().setExtensions(expectedExtensions);
+
+        GlTF outputGltf = GltfCreatorV2.create(gltfModel);
+        Asset outputAsset = outputGltf.getAsset();
+        assertEquals(inputAsset.getExtras(), outputAsset.getExtras());
+        assertEquals(expectedExtensions, outputAsset.getExtensions());
+        assertEquals(expectedCopyright, outputAsset.getCopyright());
+
+        String expectedGenerator = "JglTF from https://github.com/javagl/JglTF";
+        assertEquals(expectedGenerator, outputAsset.getGenerator());
+        assertEquals("2.0", outputAsset.getVersion());
+    }
+    
+
+}

--- a/jgltf-model/src/test/java/de/javagl/jgltf/model/TestExtensionsModelV1.java
+++ b/jgltf-model/src/test/java/de/javagl/jgltf/model/TestExtensionsModelV1.java
@@ -1,0 +1,66 @@
+/*
+ * www.javagl.de - JglTF
+ *
+ * Copyright 2015-2020 Marco Hutter - http://www.javagl.de
+ */
+package de.javagl.jgltf.model;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import de.javagl.jgltf.impl.v1.GlTF;
+import de.javagl.jgltf.model.impl.DefaultExtensionsModel;
+import de.javagl.jgltf.model.impl.DefaultGltfModel;
+import de.javagl.jgltf.model.io.v1.GltfAssetV1;
+import de.javagl.jgltf.model.v1.GltfModelCreatorV1;
+import de.javagl.jgltf.model.v1.GltfCreatorV1;
+
+/**
+ * Tests for the extensions handling in the {@link GltfModelV1}<br>
+ */
+@SuppressWarnings("javadoc")
+public class TestExtensionsModelV1
+{
+    @Test
+    public void testModelFromGltfV1() throws IOException
+    {
+        // Note that glTF 1.0 did not have 'extensionsRequired'
+        List<String> expectedExtensionsUsed =
+            Arrays.asList("TEST_extension_A", "TEST_extension_B");
+
+        GlTF gltf = new GlTF();
+        gltf.setExtensionsUsed(expectedExtensionsUsed);
+
+        DefaultGltfModel gltfModel =
+            GltfModelCreatorV1.create(new GltfAssetV1(gltf, null));
+
+        ExtensionsModel extensionsModel = gltfModel.getExtensionsModel();
+
+        List<String> actualExtensionsUsed = extensionsModel.getExtensionsUsed();
+        assertEquals(expectedExtensionsUsed, actualExtensionsUsed);
+    }
+
+    @Test
+    public void tesGltfFromModelV1() throws IOException
+    {
+        // Note that glTF 1.0 did not have 'extensionsRequired'
+        List<String> expectedExtensionsUsed =
+            Arrays.asList("TEST_extension_A", "TEST_extension_B");
+
+        DefaultGltfModel gltfModel = new DefaultGltfModel();
+        DefaultExtensionsModel extensionsModel = gltfModel.getExtensionsModel();
+        extensionsModel.addExtensionsUsed(expectedExtensionsUsed);
+
+        GlTF gltf = GltfCreatorV1.create(gltfModel);
+
+        List<String> actualExtensionsUsed = gltf.getExtensionsUsed();
+        assertEquals(expectedExtensionsUsed, actualExtensionsUsed);
+
+    }
+
+}

--- a/jgltf-model/src/test/java/de/javagl/jgltf/model/TestExtensionsModelV2.java
+++ b/jgltf-model/src/test/java/de/javagl/jgltf/model/TestExtensionsModelV2.java
@@ -1,0 +1,78 @@
+/*
+ * www.javagl.de - JglTF
+ *
+ * Copyright 2015-2020 Marco Hutter - http://www.javagl.de
+ */
+package de.javagl.jgltf.model;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import de.javagl.jgltf.impl.v2.GlTF;
+import de.javagl.jgltf.model.impl.DefaultExtensionsModel;
+import de.javagl.jgltf.model.impl.DefaultGltfModel;
+import de.javagl.jgltf.model.io.v2.GltfAssetV2;
+import de.javagl.jgltf.model.v2.GltfModelCreatorV2;
+import de.javagl.jgltf.model.v2.GltfCreatorV2;
+
+/**
+ * Tests for the extensions handling in the {@link GltfModelV2}<br>
+ */
+@SuppressWarnings("javadoc")
+public class TestExtensionsModelV2
+{
+    @Test
+    public void testModelFromGltfV2() throws IOException
+    {
+        List<String> expectedExtensionsUsed =
+            Arrays.asList("TEST_extension_A", "TEST_extension_B");
+        List<String> expectedExtensionsRequired =
+            Arrays.asList("TEST_extension_A");
+
+        GlTF gltf = new GlTF();
+        gltf.setExtensionsUsed(expectedExtensionsUsed);
+        gltf.setExtensionsRequired(expectedExtensionsRequired);
+
+        DefaultGltfModel gltfModel =
+            GltfModelCreatorV2.create(new GltfAssetV2(gltf, null));
+
+        ExtensionsModel extensionsModel = gltfModel.getExtensionsModel();
+
+        List<String> actualExtensionsUsed = extensionsModel.getExtensionsUsed();
+        assertEquals(expectedExtensionsUsed, actualExtensionsUsed);
+
+        List<String> actualExtensionsRequired =
+            extensionsModel.getExtensionsRequired();
+        assertEquals(expectedExtensionsRequired, actualExtensionsRequired);
+
+    }
+
+    @Test
+    public void tesGltfFromModelV2() throws IOException
+    {
+        List<String> expectedExtensionsUsed =
+            Arrays.asList("TEST_extension_A", "TEST_extension_B");
+        List<String> expectedExtensionsRequired =
+            Arrays.asList("TEST_extension_A");
+
+        DefaultGltfModel gltfModel = new DefaultGltfModel();
+        DefaultExtensionsModel extensionsModel = gltfModel.getExtensionsModel();
+        extensionsModel.addExtensionsUsed(expectedExtensionsUsed);
+        extensionsModel.addExtensionsRequired(expectedExtensionsRequired);
+
+        GlTF gltf = GltfCreatorV2.create(gltfModel);
+
+        List<String> actualExtensionsUsed = gltf.getExtensionsUsed();
+        assertEquals(expectedExtensionsUsed, actualExtensionsUsed);
+
+        List<String> actualExtensionsRequired =
+            gltf.getExtensionsRequired();
+        assertEquals(expectedExtensionsRequired, actualExtensionsRequired);
+    }
+
+}

--- a/jgltf-model/src/test/java/de/javagl/jgltf/model/TestShortAccessorByteStride.java
+++ b/jgltf-model/src/test/java/de/javagl/jgltf/model/TestShortAccessorByteStride.java
@@ -34,9 +34,9 @@ public class TestShortAccessorByteStride
         AccessorShortData accessorData = 
             (AccessorShortData) accessorModel.getAccessorData();
         
-        System.out.println(accessorData.get(0));
-        System.out.println(accessorData.get(1));
-        System.out.println(accessorData.get(2));
+        //System.out.println(accessorData.get(0));
+        //System.out.println(accessorData.get(1));
+        //System.out.println(accessorData.get(2));
 
         assertEquals(12, accessorData.get(0));
         assertEquals(23, accessorData.get(1));


### PR DESCRIPTION
Until now, the information about the `extensionsUsed` and `extensionsRequired` of a glTF asset could not be transported throgh the `GltfModel`. This became painfully apparent during my recent experiments for implementing certain extensions, and has been pointed out in https://github.com/javagl/JglTF/issues/75 . Similarly, the information about the `asset` was not transported though the model: Whenever a model was written to a file, then a default `asset` was inserted (only containing the `version` and predefined `generator` information). 

This PR adds model classes for these elements:

- The [`ExtensionsModel`](https://github.com/javagl/JglTF/blob/862b512f722aa25abaf1abafd45606f2602b1f50/jgltf-model/src/main/java/de/javagl/jgltf/model/ExtensionsModel.java#L31) keeps track of the used- and required extensions. The `DefaultGltfModel` contains a `DefaultExtensionsModel` that can be modified accordingly, keeping the information about used- and required extensions consistent, and adding this information to the glTF when it is written into an output file
- The [`AssetModel`](https://github.com/javagl/JglTF/blob/862b512f722aa25abaf1abafd45606f2602b1f50/jgltf-model/src/main/java/de/javagl/jgltf/model/AssetModel.java#L29) handles the 'generator' and 'copyright' information (and possible `extensions` and `extras`). The `DefaultGltfModel` contains a `DefaultAssetModel` where this information can be modified accordingly. The information will eventually be part of the `gltf.asset` when the model is written to a file. When no `generator` is given, then the default generator (JglTF) will be inserted. Note that the `version` is _not_ part of the model. That's the whole point of the 'model' in the first place. The version only depends on the version that is used for _writing_ the model.


