### PR TITLE
Do not set target for skin- and animation buffer views

### DIFF
--- a/jgltf-model-builder/src/main/java/de/javagl/jgltf/model/creation/DefaultBufferBuilderStrategy.java
+++ b/jgltf-model-builder/src/main/java/de/javagl/jgltf/model/creation/DefaultBufferBuilderStrategy.java
@@ -182,7 +182,7 @@ class DefaultBufferBuilderStrategy implements BufferBuilderStrategy
         }
         if (!animationModel.getChannels().isEmpty())
         {
-            bufferStructureBuilder.createArrayBufferViewModel("animation");
+            bufferStructureBuilder.createBufferViewModel("animation", null);
         }
     }
     
@@ -207,7 +207,7 @@ class DefaultBufferBuilderStrategy implements BufferBuilderStrategy
         AccessorModel ibm = skinModel.getInverseBindMatrices();
         bufferStructureBuilder.addAccessorModel(
             "inverse bind matrices", (DefaultAccessorModel) ibm);
-        bufferStructureBuilder.createArrayBufferViewModel("skin");
+        bufferStructureBuilder.createBufferViewModel("skin", null);
     }
     
     @Override


### PR DESCRIPTION
Noticed in the context of https://github.com/javagl/JglTF/issues/83 : 

The `DefaultBufferBuilderStrategy` created buffer views for skins and animation data that had their `target` property set, but it may not be set for buffer views of this kind. This caused validation errors like
```
BUFFER_VIEW_TARGET_OVERRIDE	Override of previously set bufferView target or usage. Initial: 'VertexBuffer', new: 'IBM'.	/skins/1/inverseBindMatrices
BUFFER_VIEW_TARGET_OVERRIDE	Override of previously set bufferView target or usage. Initial: 'VertexBuffer', new: 'Other'.	/animations/0/samplers/0/input
```
and a messed up result.

Further details and tests might be added here before this PR is merged.
