### PR TITLE
Consistently use the padded element size

### DIFF
--- a/jgltf-model-builder/src/main/java/de/javagl/jgltf/model/creation/AccessorModels.java
+++ b/jgltf-model-builder/src/main/java/de/javagl/jgltf/model/creation/AccessorModels.java
@@ -373,7 +373,7 @@ public class AccessorModels
         int commonByteStride = 1;
         for (AccessorModel accessorModel : accessorModels)
         {
-            int elementSize = accessorModel.getElementSizeInBytes();
+            int elementSize = accessorModel.getPaddedElementSizeInBytes();
             commonByteStride = Math.max(commonByteStride, elementSize);
             
             int byteStride = accessorModel.getByteStride();

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfModelCreatorV2.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfModelCreatorV2.java
@@ -528,7 +528,8 @@ public class GltfModelCreatorV2
             // When there is no BufferView referenced from the accessor,
             // then a NEW BufferViewModel (and Buffer) have to be created
             int count = accessorModel.getCount();
-            int elementSizeInBytes = accessorModel.getElementSizeInBytes();
+            int elementSizeInBytes = 
+                accessorModel.getPaddedElementSizeInBytes();
             int byteLength = elementSizeInBytes * count;
             ByteBuffer bufferData = Buffers.create(byteLength);
             String uriString = "buffer_for_accessor" + accessorIndex + ".bin";
@@ -556,7 +557,7 @@ public class GltfModelCreatorV2
         // then this BufferView has to be replaced with a new one,
         // to which the data substitution will be applied 
         int count = accessorModel.getCount();
-        int elementSizeInBytes = accessorModel.getElementSizeInBytes();
+        int elementSizeInBytes = accessorModel.getPaddedElementSizeInBytes();
         int byteLength = elementSizeInBytes * count;
         ByteBuffer bufferData = Buffers.create(byteLength);
         String uriString = "buffer_for_accessor" + accessorIndex + ".bin";

--- a/jgltf-viewer/src/main/java/de/javagl/jgltf/viewer/AccessorModelCreation.java
+++ b/jgltf-viewer/src/main/java/de/javagl/jgltf/viewer/AccessorModelCreation.java
@@ -97,7 +97,7 @@ class AccessorModelCreation
     {
         DefaultAccessorModel accessorModel =
             new DefaultAccessorModel(componentType, count, elementType);
-        int elementSize = accessorModel.getElementSizeInBytes();
+        int elementSize = accessorModel.getPaddedElementSizeInBytes();
         accessorModel.setByteOffset(0);
         
         ByteBuffer bufferData = Buffers.create(count * elementSize);


### PR DESCRIPTION
According to [3.6.2.4. Data Alignment](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#data-alignment) of the specification, padding bytes have to be inserted at the end of columns of certain `MATn` types. The general difference between an "element size" and an "element size with padding" may be that

- the element size for a `MAT2` with `GL_BYTE` is 4
- the element size with padding for a `MAT2` with `GL_BYTE` is 8

This was already anticipated, e.g. with the `ElementType` class. But some classes (most importantly the `BufferStructureBuilder`) did not anticipate this, and did write 'wrong' data into the buffers when the inputs have been one of the affected matrix types.

