### PR TITLE
Inverse bind matrices are optional

### DIFF
--- a/jgltf-model-builder/src/main/java/de/javagl/jgltf/model/creation/DefaultBufferBuilderStrategy.java
+++ b/jgltf-model-builder/src/main/java/de/javagl/jgltf/model/creation/DefaultBufferBuilderStrategy.java
@@ -205,9 +205,12 @@ class DefaultBufferBuilderStrategy implements BufferBuilderStrategy
     private void processSkinModel(SkinModel skinModel)
     {
         AccessorModel ibm = skinModel.getInverseBindMatrices();
-        bufferStructureBuilder.addAccessorModel(
-            "inverse bind matrices", (DefaultAccessorModel) ibm);
-        bufferStructureBuilder.createBufferViewModel("skin", null);
+        if (ibm != null) 
+        {
+            bufferStructureBuilder.addAccessorModel(
+                "inverse bind matrices", (DefaultAccessorModel) ibm);
+            bufferStructureBuilder.createBufferViewModel("skin", null);
+        }
     }
     
     @Override


### PR DESCRIPTION
The `BufferStructureBuilder` internally assumed that the inverse bind matrices are always non-null, but according to the specification, they are _optional_.
