### PR TITLE
Set the MIME type of image models when it was not given

### DIFF
--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/v1/GltfModelCreatorV1.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/v1/GltfModelCreatorV1.java
@@ -125,6 +125,7 @@ import de.javagl.jgltf.model.impl.DefaultTextureModel;
 import de.javagl.jgltf.model.io.Buffers;
 import de.javagl.jgltf.model.io.GltfAsset;
 import de.javagl.jgltf.model.io.IO;
+import de.javagl.jgltf.model.io.MimeTypes;
 import de.javagl.jgltf.model.io.v1.GltfAssetV1;
 import de.javagl.jgltf.model.v1.gl.DefaultModels;
 import de.javagl.jgltf.model.v1.gl.GltfDefaults;
@@ -647,6 +648,17 @@ public class GltfModelCreatorV1
                     imageModel.setImageData(imageData);
                 }
             }
+
+            // If the MIME type was not set, then detect it from the image data
+            String mimeType = imageModel.getMimeType();
+            if (mimeType == null)
+            {
+                ByteBuffer imageData = imageModel.getImageData();
+                mimeType =
+                    MimeTypes.guessImageMimeTypeStringUnchecked(imageData);
+                imageModel.setMimeType(mimeType);
+            }
+            
         }
     }
     

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfModelCreatorV2.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfModelCreatorV2.java
@@ -112,6 +112,7 @@ import de.javagl.jgltf.model.impl.DefaultTextureModel;
 import de.javagl.jgltf.model.io.Buffers;
 import de.javagl.jgltf.model.io.GltfAsset;
 import de.javagl.jgltf.model.io.IO;
+import de.javagl.jgltf.model.io.MimeTypes;
 import de.javagl.jgltf.model.io.v2.GltfAssetV2;
 import de.javagl.jgltf.model.v2.MaterialModelV2.AlphaMode;
 import de.javagl.jgltf.model.v2.gl.Materials;
@@ -1127,6 +1128,16 @@ public class GltfModelCreatorV2
                     ByteBuffer imageData = gltfAsset.getReferenceData(uri);
                     imageModel.setImageData(imageData);
                 }
+            }
+            
+            // If the MIME type was not set, then detect it from the image data
+            String mimeType = imageModel.getMimeType();
+            if (mimeType == null)
+            {
+                ByteBuffer imageData = imageModel.getImageData();
+                mimeType =
+                    MimeTypes.guessImageMimeTypeStringUnchecked(imageData);
+                imageModel.setMimeType(mimeType);
             }
         }
     }


### PR DESCRIPTION
When reading a glTF, then the `mimeType` of `ImageModel` objects was not always initialized (namely, when it was not defined in the input).

This PR fixes this: As soon as the image data of an image model is known, it will try to set the MIME type based on the image data, iff the MIME type was not already set.
