### PR TITLE
Prevent crash when loading meshopt-compressed models

### DIFF
--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfModelCreatorV2.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfModelCreatorV2.java
@@ -848,6 +848,9 @@ public class GltfModelCreatorV2
                         logger.warning("Buffer " + i + " does not have "
                             + "a uri. Binary chunks that are not the main GLB "
                             + "buffer are not supported.");
+                        ByteBuffer fallbackBuffer =
+                            ByteBuffer.allocate(buffer.getByteLength());
+                        bufferModel.setBufferData(fallbackBuffer);
                     }
                     else
                     {


### PR DESCRIPTION

#### JglTF does **not** support `EXT_meshopt_compression`! 

(And hardly any other extensions - see https://github.com/javagl/JglTF/issues/109)

This PR only pragmatically prevents a crash (`NullPointerException`) when trying to load a meshopt-compressed model.

As part of broader extension support, JglTF should check whether a given asset contains `extensionsRequired` that are not supported (like meshopt, usually), and handle this case... differently.

