### PR TITLE
Change TRS+matrix floating-point precision to double

### DIFF
--- a/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/Node.java
+++ b/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/Node.java
@@ -75,7 +75,7 @@ public class Node
      * &nbsp;&nbsp;The elements of this array (optional) 
      * 
      */
-    private float[] matrix;
+    private double[] matrix;
     /**
      * The IDs of the meshes in this node. (optional)<br> 
      * Array elements:<br> 
@@ -92,7 +92,7 @@ public class Node
      * &nbsp;&nbsp;The elements of this array (optional) 
      * 
      */
-    private float[] rotation;
+    private double[] rotation;
     /**
      * The node's non-uniform scale. (optional)<br> 
      * Default: [1.0,1.0,1.0]<br> 
@@ -101,7 +101,7 @@ public class Node
      * &nbsp;&nbsp;The elements of this array (optional) 
      * 
      */
-    private float[] scale;
+    private double[] scale;
     /**
      * The node's translation. (optional)<br> 
      * Default: [0.0,0.0,0.0]<br> 
@@ -110,7 +110,7 @@ public class Node
      * &nbsp;&nbsp;The elements of this array (optional) 
      * 
      */
-    private float[] translation;
+    private double[] translation;
 
     /**
      * The ID of the camera referenced by this node. (optional) 
@@ -367,7 +367,7 @@ public class Node
      * the given constraints
      * 
      */
-    public void setMatrix(float[] matrix) {
+    public void setMatrix(double[] matrix) {
         if (matrix == null) {
             this.matrix = matrix;
             return ;
@@ -393,7 +393,7 @@ public class Node
      * @return The matrix
      * 
      */
-    public float[] getMatrix() {
+    public double[] getMatrix() {
         return this.matrix;
     }
 
@@ -404,8 +404,8 @@ public class Node
      * @return The default matrix
      * 
      */
-    public float[] defaultMatrix() {
-        return new float[] { 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F };
+    public double[] defaultMatrix() {
+        return new double[] { 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 };
     }
 
     /**
@@ -499,7 +499,7 @@ public class Node
      * the given constraints
      * 
      */
-    public void setRotation(float[] rotation) {
+    public void setRotation(double[] rotation) {
         if (rotation == null) {
             this.rotation = rotation;
             return ;
@@ -524,7 +524,7 @@ public class Node
      * @return The rotation
      * 
      */
-    public float[] getRotation() {
+    public double[] getRotation() {
         return this.rotation;
     }
 
@@ -535,8 +535,8 @@ public class Node
      * @return The default rotation
      * 
      */
-    public float[] defaultRotation() {
-        return new float[] { 0.0F, 0.0F, 0.0F, 1.0F };
+    public double[] defaultRotation() {
+        return new double[] { 0.0, 0.0, 0.0, 1.0 };
     }
 
     /**
@@ -551,7 +551,7 @@ public class Node
      * the given constraints
      * 
      */
-    public void setScale(float[] scale) {
+    public void setScale(double[] scale) {
         if (scale == null) {
             this.scale = scale;
             return ;
@@ -575,7 +575,7 @@ public class Node
      * @return The scale
      * 
      */
-    public float[] getScale() {
+    public double[] getScale() {
         return this.scale;
     }
 
@@ -586,8 +586,8 @@ public class Node
      * @return The default scale
      * 
      */
-    public float[] defaultScale() {
-        return new float[] { 1.0F, 1.0F, 1.0F };
+    public double[] defaultScale() {
+        return new double[] { 1.0, 1.0, 1.0 };
     }
 
     /**
@@ -602,7 +602,7 @@ public class Node
      * the given constraints
      * 
      */
-    public void setTranslation(float[] translation) {
+    public void setTranslation(double[] translation) {
         if (translation == null) {
             this.translation = translation;
             return ;
@@ -626,7 +626,7 @@ public class Node
      * @return The translation
      * 
      */
-    public float[] getTranslation() {
+    public double[] getTranslation() {
         return this.translation;
     }
 
@@ -637,8 +637,8 @@ public class Node
      * @return The default translation
      * 
      */
-    public float[] defaultTranslation() {
-        return new float[] { 0.0F, 0.0F, 0.0F };
+    public double[] defaultTranslation() {
+        return new double[] { 0.0, 0.0, 0.0 };
     }
 
 }

--- a/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/Skin.java
+++ b/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/Skin.java
@@ -32,7 +32,7 @@ public class Skin
      * &nbsp;&nbsp;The elements of this array (optional) 
      * 
      */
-    private float[] bindShapeMatrix;
+    private double[] bindShapeMatrix;
     /**
      * The ID of the accessor containing the floating-point 4x4 inverse-bind 
      * matrices. (required) 
@@ -62,7 +62,7 @@ public class Skin
      * the given constraints
      * 
      */
-    public void setBindShapeMatrix(float[] bindShapeMatrix) {
+    public void setBindShapeMatrix(double[] bindShapeMatrix) {
         if (bindShapeMatrix == null) {
             this.bindShapeMatrix = bindShapeMatrix;
             return ;
@@ -88,7 +88,7 @@ public class Skin
      * @return The bindShapeMatrix
      * 
      */
-    public float[] getBindShapeMatrix() {
+    public double[] getBindShapeMatrix() {
         return this.bindShapeMatrix;
     }
 

--- a/jgltf-impl-v2/src/main/java/de/javagl/jgltf/impl/v2/Node.java
+++ b/jgltf-impl-v2/src/main/java/de/javagl/jgltf/impl/v2/Node.java
@@ -60,7 +60,7 @@ public class Node
      * &nbsp;&nbsp;The elements of this array (optional) 
      * 
      */
-    private float[] matrix;
+    private double[] matrix;
     /**
      * The index of the mesh in this node. (optional) 
      * 
@@ -77,7 +77,7 @@ public class Node
      * &nbsp;&nbsp;Maximum: 1.0 (inclusive) 
      * 
      */
-    private float[] rotation;
+    private double[] rotation;
     /**
      * The node's non-uniform scale, given as the scaling factors along the 
      * x, y, and z axes. (optional)<br> 
@@ -87,7 +87,7 @@ public class Node
      * &nbsp;&nbsp;The elements of this array (optional) 
      * 
      */
-    private float[] scale;
+    private double[] scale;
     /**
      * The node's translation along the x, y, and z axes. (optional)<br> 
      * Default: [0.0,0.0,0.0]<br> 
@@ -96,7 +96,7 @@ public class Node
      * &nbsp;&nbsp;The elements of this array (optional) 
      * 
      */
-    private float[] translation;
+    private double[] translation;
     /**
      * The weights of the instantiated morph target. The number of array 
      * elements **MUST** match the number of morph targets of the referenced 
@@ -262,7 +262,7 @@ public class Node
      * the given constraints
      * 
      */
-    public void setMatrix(float[] matrix) {
+    public void setMatrix(double[] matrix) {
         if (matrix == null) {
             this.matrix = matrix;
             return ;
@@ -288,7 +288,7 @@ public class Node
      * @return The matrix
      * 
      */
-    public float[] getMatrix() {
+    public double[] getMatrix() {
         return this.matrix;
     }
 
@@ -299,8 +299,8 @@ public class Node
      * @return The default matrix
      * 
      */
-    public float[] defaultMatrix() {
-        return new float[] { 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F };
+    public double[] defaultMatrix() {
+        return new double[] { 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 };
     }
 
     /**
@@ -342,7 +342,7 @@ public class Node
      * the given constraints
      * 
      */
-    public void setRotation(float[] rotation) {
+    public void setRotation(double[] rotation) {
         if (rotation == null) {
             this.rotation = rotation;
             return ;
@@ -353,7 +353,7 @@ public class Node
         if (rotation.length > 4) {
             throw new IllegalArgumentException("Number of rotation elements is > 4");
         }
-        for (float rotationElement: rotation) {
+        for (double rotationElement: rotation) {
             if (rotationElement > 1.0D) {
                 throw new IllegalArgumentException("rotationElement > 1.0");
             }
@@ -377,7 +377,7 @@ public class Node
      * @return The rotation
      * 
      */
-    public float[] getRotation() {
+    public double[] getRotation() {
         return this.rotation;
     }
 
@@ -388,8 +388,8 @@ public class Node
      * @return The default rotation
      * 
      */
-    public float[] defaultRotation() {
-        return new float[] { 0.0F, 0.0F, 0.0F, 1.0F };
+    public double[] defaultRotation() {
+        return new double[] { 0.0, 0.0, 0.0, 1.0 };
     }
 
     /**
@@ -405,7 +405,7 @@ public class Node
      * the given constraints
      * 
      */
-    public void setScale(float[] scale) {
+    public void setScale(double[] scale) {
         if (scale == null) {
             this.scale = scale;
             return ;
@@ -430,7 +430,7 @@ public class Node
      * @return The scale
      * 
      */
-    public float[] getScale() {
+    public double[] getScale() {
         return this.scale;
     }
 
@@ -441,8 +441,8 @@ public class Node
      * @return The default scale
      * 
      */
-    public float[] defaultScale() {
-        return new float[] { 1.0F, 1.0F, 1.0F };
+    public double[] defaultScale() {
+        return new double[] { 1.0, 1.0, 1.0 };
     }
 
     /**
@@ -457,7 +457,7 @@ public class Node
      * the given constraints
      * 
      */
-    public void setTranslation(float[] translation) {
+    public void setTranslation(double[] translation) {
         if (translation == null) {
             this.translation = translation;
             return ;
@@ -481,7 +481,7 @@ public class Node
      * @return The translation
      * 
      */
-    public float[] getTranslation() {
+    public double[] getTranslation() {
         return this.translation;
     }
 
@@ -492,8 +492,8 @@ public class Node
      * @return The default translation
      * 
      */
-    public float[] defaultTranslation() {
-        return new float[] { 0.0F, 0.0F, 0.0F };
+    public double[] defaultTranslation() {
+        return new double[] { 0.0, 0.0, 0.0 };
     }
 
     /**

--- a/jgltf-model-builder/src/test/java/de/javagl/jgltf/model/creation/DuplicateMeshesTest.java
+++ b/jgltf-model-builder/src/test/java/de/javagl/jgltf/model/creation/DuplicateMeshesTest.java
@@ -61,12 +61,12 @@ public class DuplicateMeshesTest
         
         // Add the same mesh to the scene twice
         DefaultNodeModel nodeModel0 = new DefaultNodeModel();
-        nodeModel0.setTranslation(new float[] { -1.0f, 0, 0 });
+        nodeModel0.setTranslation(new double[] { -1.0, 0, 0 });
         nodeModel0.addMeshModel(meshModel);
         sceneModel.addNode(nodeModel0);
 
         DefaultNodeModel nodeModel1 = new DefaultNodeModel();
-        nodeModel1.setTranslation(new float[] { 1.0f, 0, 0 });
+        nodeModel1.setTranslation(new double[] { 1.0, 0, 0 });
         nodeModel1.addMeshModel(meshModel);
         sceneModel.addNode(nodeModel1);
         

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/BoundingBox.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/BoundingBox.java
@@ -36,44 +36,44 @@ class BoundingBox
     /**
      * The minimum x coordinate
      */
-    private float minX;
+    private double minX;
     
     /**
      * The minimum y coordinate
      */
-    private float minY;
+    private double minY;
     
     /**
      * The minimum z coordinate
      */
-    private float minZ;
+    private double minZ;
     
     /**
      * The maximum x coordinate
      */
-    private float maxX;
+    private double maxX;
     
     /**
      * The maximum y coordinate
      */
-    private float maxY;
+    private double maxY;
     
     /**
      * The maximum z coordinate
      */
-    private float maxZ;
+    private double maxZ;
 
     /**
      * Creates a bounding box  
      */
     BoundingBox()
     {
-        minX = Float.MAX_VALUE;
-        minY = Float.MAX_VALUE;
-        minZ = Float.MAX_VALUE;
-        maxX = -Float.MAX_VALUE;
-        maxY = -Float.MAX_VALUE;
-        maxZ = -Float.MAX_VALUE;
+        minX = Double.MAX_VALUE;
+        minY = Double.MAX_VALUE;
+        minZ = Double.MAX_VALUE;
+        maxX = -Double.MAX_VALUE;
+        maxY = -Double.MAX_VALUE;
+        maxZ = -Double.MAX_VALUE;
     }
     
     /**
@@ -114,7 +114,7 @@ class BoundingBox
      *
      * @return The x-coordinate of the center
      */
-    float getCenterX()
+    double getCenterX()
     {
         return getMinX() + getSizeX() * 0.5f;
     }
@@ -124,7 +124,7 @@ class BoundingBox
      *
      * @return The y-coordinate of the center
      */
-    float getCenterY()
+    double getCenterY()
     {
         return getMinY() + getSizeY() * 0.5f;
     }
@@ -134,7 +134,7 @@ class BoundingBox
      *
      * @return The z-coordinate of the center
      */
-    float getCenterZ()
+    double getCenterZ()
     {
         return getMinZ() + getSizeZ() * 0.5f;
     }
@@ -144,7 +144,7 @@ class BoundingBox
      *
      * @return The size in x-direction
      */
-    float getSizeX()
+    double getSizeX()
     {
         return getMaxX() - getMinX();
     }
@@ -154,7 +154,7 @@ class BoundingBox
      *
      * @return The size in y-direction
      */
-    float getSizeY()
+    double getSizeY()
     {
         return getMaxY() - getMinY();
     }
@@ -164,7 +164,7 @@ class BoundingBox
      *
      * @return The size in z-direction
      */
-    float getSizeZ()
+    double getSizeZ()
     {
         return getMaxZ() - getMinZ();
     }
@@ -174,7 +174,7 @@ class BoundingBox
      *
      * @return The minimum x coordinate
      */
-    float getMinX()
+    double getMinX()
     {
         return minX;
     }
@@ -184,7 +184,7 @@ class BoundingBox
      *
      * @return The minimum y coordinate
      */
-    float getMinY()
+    double getMinY()
     {
         return minY;
     }
@@ -194,7 +194,7 @@ class BoundingBox
      *
      * @return The minimum z coordinate
      */
-    float getMinZ()
+    double getMinZ()
     {
         return minZ;
     }
@@ -204,7 +204,7 @@ class BoundingBox
      *
      * @return The maximum x coordinate
      */
-    float getMaxX()
+    double getMaxX()
     {
         return maxX;
     }
@@ -214,7 +214,7 @@ class BoundingBox
      *
      * @return The maximum y coordinate
      */
-    float getMaxY()
+    double getMaxY()
     {
         return maxY;
     }
@@ -224,7 +224,7 @@ class BoundingBox
      *
      * @return The maximum z coordinate
      */
-    float getMaxZ()
+    double getMaxZ()
     {
         return maxZ;
     }

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/BoundingBoxComputer.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/BoundingBoxComputer.java
@@ -67,7 +67,7 @@ class BoundingBoxComputer
         List<SceneModel> sceneModels = gltfModel.getSceneModels();
         for (SceneModel sceneModel : sceneModels)
         {
-            float rootTransform[] = MathUtils.createIdentity4x4();
+            double rootTransform[] = MathUtils.createIdentity4x4();
             computeSceneBoundingBox(sceneModel, rootTransform, boundingBox);
         }
         return boundingBox;
@@ -86,7 +86,7 @@ class BoundingBoxComputer
      * @return The result
      */
     private BoundingBox computeSceneBoundingBox(
-        SceneModel sceneModel, float transform[], BoundingBox boundingBox)
+        SceneModel sceneModel, double transform[], BoundingBox boundingBox)
     {
         BoundingBox localResult = boundingBox;
         if (localResult == null)
@@ -115,7 +115,7 @@ class BoundingBoxComputer
      * @return The result
      */
     private BoundingBox computeNodeBoundingBox(
-        NodeModel nodeModel, float parentTransform[], BoundingBox boundingBox) 
+        NodeModel nodeModel, double parentTransform[], BoundingBox boundingBox)
     {
         BoundingBox result = boundingBox;
         if (result == null)
@@ -123,8 +123,8 @@ class BoundingBoxComputer
             result = new BoundingBox();
         }
 
-        float[] localTransform = nodeModel.computeLocalTransform(null);
-        float[] transform = new float[16];
+        double[] localTransform = nodeModel.computeLocalTransform(null);
+        double[] transform = new double[16];
         MathUtils.mul4x4(parentTransform, localTransform, transform);
         
         List<MeshModel> meshModels = nodeModel.getMeshModels();
@@ -157,7 +157,7 @@ class BoundingBoxComputer
      * @return The result
      */
     private BoundingBox computeMeshBoundingBox(
-        MeshModel meshModel, float transform[], BoundingBox boundingBox)
+        MeshModel meshModel, double transform[], BoundingBox boundingBox)
     {
         BoundingBox result = boundingBox;
         if (result == null)
@@ -194,7 +194,7 @@ class BoundingBoxComputer
      * returned. 
      */
     private BoundingBox computeBoundingBox(
-        MeshPrimitiveModel meshPrimitiveModel, float transform[])
+        MeshPrimitiveModel meshPrimitiveModel, double transform[])
     {
         Map<String, AccessorModel> attributes = 
             meshPrimitiveModel.getAttributes();

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/BoundingBoxes.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/BoundingBoxes.java
@@ -43,15 +43,15 @@ public class BoundingBoxes
      * @param gltfModel The {@link GltfModel}
      * @return The bounding box
      */
-    public static float[] computeBoundingBoxMinMax(GltfModel gltfModel)
+    public static double[] computeBoundingBoxMinMax(GltfModel gltfModel)
     {
         Objects.requireNonNull(gltfModel, "The gltfModel may not be null");
         
         BoundingBoxComputer boundingBoxComputer =
             new BoundingBoxComputer(gltfModel);
         BoundingBox boundingBox = boundingBoxComputer.compute();
-        
-        float result[] = {
+
+        double result[] = {
             boundingBox.getMinX(),
             boundingBox.getMinY(),
             boundingBox.getMinZ(),

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/CameraModel.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/CameraModel.java
@@ -65,7 +65,7 @@ public interface CameraModel extends NamedModelElement
      * camera will be used.
      * @return The result array
      */
-    float[] computeProjectionMatrix(float result[], Float aspectRatio);
+    double[] computeProjectionMatrix(double result[], Float aspectRatio);
 
     /**
      * Create the supplier of the projection matrix for this camera model.<br>
@@ -84,7 +84,7 @@ public interface CameraModel extends NamedModelElement
      * aspect ratio of the camera will be used.
      * @return The supplier
      */
-    Supplier<float[]> createProjectionMatrixSupplier(
+    Supplier<double[]> createProjectionMatrixSupplier(
         DoubleSupplier aspectRatioSupplier);
 
 }

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/GltfAnimations.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/GltfAnimations.java
@@ -308,15 +308,22 @@ public class GltfAnimations
     {
         return (animation, timeS, values) ->
         {
-            float translation[] = nodeModel.getTranslation();
+            double translation[] = nodeModel.getTranslation();
             if (translation == null)
             {
-                translation = values.clone();
+                translation = new double[values.length];
+                for (int i = 0; i < values.length; i++)
+                {
+                    translation[i] = values[i];
+                }
                 nodeModel.setTranslation(translation);
             }
             else
             {
-                System.arraycopy(values, 0, translation, 0, values.length);
+                for (int i = 0; i < values.length; i++)
+                {
+                    translation[i] = values[i];
+                }
             }
         };
     }
@@ -334,15 +341,22 @@ public class GltfAnimations
     {
         return (animation, timeS, values) ->
         {
-            float rotation[] = nodeModel.getRotation();
+            double rotation[] = nodeModel.getRotation();
             if (rotation == null)
             {
-                rotation = values.clone();
+                rotation = new double[values.length];
+                for (int i = 0; i < values.length; i++)
+                {
+                    rotation[i] = values[i];
+                }
                 nodeModel.setRotation(rotation);
             }
             else
             {
-                System.arraycopy(values, 0, rotation, 0, values.length);
+                for (int i = 0; i < values.length; i++)
+                {
+                    rotation[i] = values[i];
+                }
             }
         };
     }
@@ -360,15 +374,22 @@ public class GltfAnimations
     {
         return (animation, timeS, values) ->
         {
-            float scale[] = nodeModel.getScale();
+            double scale[] = nodeModel.getScale();
             if (scale == null)
             {
-                scale = values.clone();
+                scale = new double[values.length];
+                for (int i = 0; i < values.length; i++)
+                {
+                    scale[i] = values[i];
+                }
                 nodeModel.setScale(scale);
             }
             else
             {
-                System.arraycopy(values, 0, scale, 0, values.length);
+                for (int i = 0; i < values.length; i++)
+                {
+                    scale[i] = values[i];
+                }
             }
         };
     }

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/MathUtils.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/MathUtils.java
@@ -58,16 +58,16 @@ public class MathUtils
     /**
      * Epsilon for floating point computations
      */
-    private static final float FLOAT_EPSILON = 1e-8f;
+    private static final double FLOAT_EPSILON = 1e-8f;
     
     /**
      * Creates a 4x4 identity matrix
      * 
      * @return The matrix
      */
-    public static float[] createIdentity4x4()
+    public static double[] createIdentity4x4()
     {
-        float m[] = new float[16];
+        double m[] = new double[16];
         setIdentity4x4(m);
         return m;
     }
@@ -77,7 +77,7 @@ public class MathUtils
      * 
      * @param m The matrix
      */
-    public static void setIdentity4x4(float m[])
+    public static void setIdentity4x4(double m[])
     {
         Arrays.fill(m, 0.0f);
         m[0] = 1.0f;
@@ -91,7 +91,7 @@ public class MathUtils
      * 
      * @param m The matrix
      */
-    static void setIdentity3x3(float m[])
+    static void setIdentity3x3(double m[])
     {
         Arrays.fill(m, 0.0f);
         m[0] = 1.0f;
@@ -107,7 +107,7 @@ public class MathUtils
      * @param source The source array
      * @param target The target array
      */
-    static void set(float source[], float target[])
+    static void set(double source[], double target[])
     {
         System.arraycopy(source, 0, target, 0, 
             Math.min(source.length, target.length));
@@ -122,7 +122,7 @@ public class MathUtils
      * @param targetMatrix3x3 The target matrix
      */
     public static void getRotationScale(
-        float sourceMatrix4x4[], float targetMatrix3x3[])
+        double sourceMatrix4x4[], double targetMatrix3x3[])
     {
         targetMatrix3x3[0] = sourceMatrix4x4[ 0];
         targetMatrix3x3[1] = sourceMatrix4x4[ 1];
@@ -143,17 +143,17 @@ public class MathUtils
      * @param m The input matrix
      * @param t The target matrix
      */
-    static void transpose3x3(float m[], float t[])
+    static void transpose3x3(double m[], double t[])
     {
-        float m0 = m[0];
-        float m1 = m[1];
-        float m2 = m[2];
-        float m3 = m[3];
-        float m4 = m[4];
-        float m5 = m[5];
-        float m6 = m[6];
-        float m7 = m[7];
-        float m8 = m[8];
+        double m0 = m[0];
+        double m1 = m[1];
+        double m2 = m[2];
+        double m3 = m[3];
+        double m4 = m[4];
+        double m5 = m[5];
+        double m6 = m[6];
+        double m7 = m[7];
+        double m8 = m[8];
         t[0] = m0;
         t[1] = m3;
         t[2] = m6;
@@ -172,24 +172,24 @@ public class MathUtils
      * @param m The input matrix
      * @param t The target matrix
      */
-    public static void transpose4x4(float m[], float t[])
+    public static void transpose4x4(double m[], double t[])
     {
-        float m0 = m[ 0];
-        float m1 = m[ 1];
-        float m2 = m[ 2];
-        float m3 = m[ 3];
-        float m4 = m[ 4];
-        float m5 = m[ 5];
-        float m6 = m[ 6];
-        float m7 = m[ 7];
-        float m8 = m[ 8];
-        float m9 = m[ 9];
-        float mA = m[10];
-        float mB = m[11];
-        float mC = m[12];
-        float mD = m[13];
-        float mE = m[14];
-        float mF = m[15];
+        double m0 = m[ 0];
+        double m1 = m[ 1];
+        double m2 = m[ 2];
+        double m3 = m[ 3];
+        double m4 = m[ 4];
+        double m5 = m[ 5];
+        double m6 = m[ 6];
+        double m7 = m[ 7];
+        double m8 = m[ 8];
+        double m9 = m[ 9];
+        double mA = m[10];
+        double mB = m[11];
+        double mC = m[12];
+        double mD = m[13];
+        double mE = m[14];
+        double mF = m[15];
         t[ 0] = m0;
         t[ 1] = m4;
         t[ 2] = m8;
@@ -215,61 +215,61 @@ public class MathUtils
      * @param b The second matrix
      * @param m The result matrix
      */
-    public static void mul4x4(float a[], float b[], float m[])
+    public static void mul4x4(double a[], double b[], double m[])
     {
-        float a00 = a[ 0];
-        float a10 = a[ 1];
-        float a20 = a[ 2];
-        float a30 = a[ 3];
-        float a01 = a[ 4];
-        float a11 = a[ 5];
-        float a21 = a[ 6];
-        float a31 = a[ 7];
-        float a02 = a[ 8];
-        float a12 = a[ 9];
-        float a22 = a[10];
-        float a32 = a[11];
-        float a03 = a[12];
-        float a13 = a[13];
-        float a23 = a[14];
-        float a33 = a[15];
+        double a00 = a[ 0];
+        double a10 = a[ 1];
+        double a20 = a[ 2];
+        double a30 = a[ 3];
+        double a01 = a[ 4];
+        double a11 = a[ 5];
+        double a21 = a[ 6];
+        double a31 = a[ 7];
+        double a02 = a[ 8];
+        double a12 = a[ 9];
+        double a22 = a[10];
+        double a32 = a[11];
+        double a03 = a[12];
+        double a13 = a[13];
+        double a23 = a[14];
+        double a33 = a[15];
 
-        float b00 = b[ 0];
-        float b10 = b[ 1];
-        float b20 = b[ 2];
-        float b30 = b[ 3];
-        float b01 = b[ 4];
-        float b11 = b[ 5];
-        float b21 = b[ 6];
-        float b31 = b[ 7];
-        float b02 = b[ 8];
-        float b12 = b[ 9];
-        float b22 = b[10];
-        float b32 = b[11];
-        float b03 = b[12];
-        float b13 = b[13];
-        float b23 = b[14];
-        float b33 = b[15];
+        double b00 = b[ 0];
+        double b10 = b[ 1];
+        double b20 = b[ 2];
+        double b30 = b[ 3];
+        double b01 = b[ 4];
+        double b11 = b[ 5];
+        double b21 = b[ 6];
+        double b31 = b[ 7];
+        double b02 = b[ 8];
+        double b12 = b[ 9];
+        double b22 = b[10];
+        double b32 = b[11];
+        double b03 = b[12];
+        double b13 = b[13];
+        double b23 = b[14];
+        double b33 = b[15];
 
-        float m00 = a00 * b00 + a01 * b10 + a02 * b20 + a03 * b30;
-        float m01 = a00 * b01 + a01 * b11 + a02 * b21 + a03 * b31;
-        float m02 = a00 * b02 + a01 * b12 + a02 * b22 + a03 * b32;
-        float m03 = a00 * b03 + a01 * b13 + a02 * b23 + a03 * b33;
+        double m00 = a00 * b00 + a01 * b10 + a02 * b20 + a03 * b30;
+        double m01 = a00 * b01 + a01 * b11 + a02 * b21 + a03 * b31;
+        double m02 = a00 * b02 + a01 * b12 + a02 * b22 + a03 * b32;
+        double m03 = a00 * b03 + a01 * b13 + a02 * b23 + a03 * b33;
 
-        float m10 = a10 * b00 + a11 * b10 + a12 * b20 + a13 * b30;
-        float m11 = a10 * b01 + a11 * b11 + a12 * b21 + a13 * b31;
-        float m12 = a10 * b02 + a11 * b12 + a12 * b22 + a13 * b32;
-        float m13 = a10 * b03 + a11 * b13 + a12 * b23 + a13 * b33;
+        double m10 = a10 * b00 + a11 * b10 + a12 * b20 + a13 * b30;
+        double m11 = a10 * b01 + a11 * b11 + a12 * b21 + a13 * b31;
+        double m12 = a10 * b02 + a11 * b12 + a12 * b22 + a13 * b32;
+        double m13 = a10 * b03 + a11 * b13 + a12 * b23 + a13 * b33;
 
-        float m20 = a20 * b00 + a21 * b10 + a22 * b20 + a23 * b30;
-        float m21 = a20 * b01 + a21 * b11 + a22 * b21 + a23 * b31;
-        float m22 = a20 * b02 + a21 * b12 + a22 * b22 + a23 * b32;
-        float m23 = a20 * b03 + a21 * b13 + a22 * b23 + a23 * b33;
+        double m20 = a20 * b00 + a21 * b10 + a22 * b20 + a23 * b30;
+        double m21 = a20 * b01 + a21 * b11 + a22 * b21 + a23 * b31;
+        double m22 = a20 * b02 + a21 * b12 + a22 * b22 + a23 * b32;
+        double m23 = a20 * b03 + a21 * b13 + a22 * b23 + a23 * b33;
 
-        float m30 = a30 * b00 + a31 * b10 + a32 * b20 + a33 * b30;
-        float m31 = a30 * b01 + a31 * b11 + a32 * b21 + a33 * b31;
-        float m32 = a30 * b02 + a31 * b12 + a32 * b22 + a33 * b32;
-        float m33 = a30 * b03 + a31 * b13 + a32 * b23 + a33 * b33;
+        double m30 = a30 * b00 + a31 * b10 + a32 * b20 + a33 * b30;
+        double m31 = a30 * b01 + a31 * b11 + a32 * b21 + a33 * b31;
+        double m32 = a30 * b02 + a31 * b12 + a32 * b22 + a33 * b32;
+        double m33 = a30 * b03 + a31 * b13 + a32 * b23 + a33 * b33;
 
         m[ 0] = m00;
         m[ 1] = m10;
@@ -298,15 +298,15 @@ public class MathUtils
      * @param q The quaternion
      * @param m The matrix
      */
-    public static void quaternionToMatrix4x4(float q[], float m[])
+    public static void quaternionToMatrix4x4(double q[], double m[])
     {
-        float invLength = 1.0f / (float)Math.sqrt(dot(q, q));
+        double invLength = 1.0f / Math.sqrt(dot(q, q));
 
         // Adapted from javax.vecmath.Matrix4f
-        float qx = q[0] * invLength;
-        float qy = q[1] * invLength;
-        float qz = q[2] * invLength;
-        float qw = q[3] * invLength;
+        double qx = q[0] * invLength;
+        double qy = q[1] * invLength;
+        double qz = q[2] * invLength;
+        double qw = q[3] * invLength;
         m[ 0] = 1.0f - 2.0f * qy * qy - 2.0f * qz * qz;
         m[ 1] = 2.0f * (qx * qy + qw * qz);
         m[ 2] = 2.0f * (qx * qz - qw * qy);
@@ -333,27 +333,27 @@ public class MathUtils
      * @param m The input matrix
      * @param inv The inverse matrix
      */
-    public static void invert4x4(float m[], float inv[])
+    public static void invert4x4(double m[], double inv[])
     {
         // Adapted from The Mesa 3-D graphics library. 
         // Copyright (C) 1999-2007  Brian Paul   All Rights Reserved.
         // Published under the MIT license (see the header of this file)
-        float m0 = m[ 0];
-        float m1 = m[ 1];
-        float m2 = m[ 2];
-        float m3 = m[ 3];
-        float m4 = m[ 4];
-        float m5 = m[ 5];
-        float m6 = m[ 6];
-        float m7 = m[ 7];
-        float m8 = m[ 8];
-        float m9 = m[ 9];
-        float mA = m[10];
-        float mB = m[11];
-        float mC = m[12];
-        float mD = m[13];
-        float mE = m[14];
-        float mF = m[15];
+        double m0 = m[ 0];
+        double m1 = m[ 1];
+        double m2 = m[ 2];
+        double m3 = m[ 3];
+        double m4 = m[ 4];
+        double m5 = m[ 5];
+        double m6 = m[ 6];
+        double m7 = m[ 7];
+        double m8 = m[ 8];
+        double m9 = m[ 9];
+        double mA = m[10];
+        double mB = m[11];
+        double mC = m[12];
+        double mD = m[13];
+        double mE = m[14];
+        double mF = m[15];
 
         inv[ 0] =  m5 * mA * mF - m5 * mB * mE - m9 * m6 * mF + 
                    m9 * m7 * mE + mD * m6 * mB - mD * m7 * mA;
@@ -389,7 +389,7 @@ public class MathUtils
                    m4 * m2 * m9 + m8 * m1 * m6 - m8 * m2 * m5;
         // (Ain't that pretty?)
         
-        float det = m0 * inv[0] + m1 * inv[4] + m2 * inv[8] + m3 * inv[12];
+        double det = m0 * inv[0] + m1 * inv[4] + m2 * inv[8] + m3 * inv[12];
         if (Math.abs(det) <= FLOAT_EPSILON)
         {
             if (logger.isLoggable(Level.FINE)) 
@@ -400,7 +400,7 @@ public class MathUtils
             setIdentity4x4(inv);
             return;
         }
-        float invDet = 1.0f / det;
+        double invDet = 1.0f / det;
         for (int i = 0; i < 16; i++)
         {
             inv[i] *= invDet;
@@ -415,19 +415,19 @@ public class MathUtils
      * @param m The input matrix
      * @param inv The inverse matrix
      */
-    public static void invert3x3(float m[], float inv[])
+    public static void invert3x3(double m[], double inv[])
     {
         // Adapted from http://stackoverflow.com/a/18504573
-        float m0 = m[0];
-        float m1 = m[1];
-        float m2 = m[2];
-        float m3 = m[3];
-        float m4 = m[4];
-        float m5 = m[5];
-        float m6 = m[6];
-        float m7 = m[7];
-        float m8 = m[8];
-        float det = m0 * (m4 * m8 - m5 * m7) -
+        double m0 = m[0];
+        double m1 = m[1];
+        double m2 = m[2];
+        double m3 = m[3];
+        double m4 = m[4];
+        double m5 = m[5];
+        double m6 = m[6];
+        double m7 = m[7];
+        double m8 = m[8];
+        double det = m0 * (m4 * m8 - m5 * m7) -
                     m3 * (m1 * m8 - m7 * m2) +
                     m6 * (m1 * m5 - m4 * m2);
         if (Math.abs(det) <= FLOAT_EPSILON)
@@ -440,7 +440,7 @@ public class MathUtils
             setIdentity3x3(inv);
             return;
         }
-        float invDet = 1.0f / det;
+        double invDet = 1.0f / det;
         inv[0] = (m4 * m8 - m5 * m7) * invDet;
         inv[3] = (m6 * m5 - m3 * m8) * invDet;
         inv[6] = (m3 * m7 - m6 * m4) * invDet;
@@ -463,7 +463,7 @@ public class MathUtils
      * @param result The result matrix
      */
     public static void translate(
-        float m[], float x, float y, float z, float result[])
+        double m[], double x, double y, double z, double result[])
     {
         set(m,  result);
         result[12] += x;
@@ -481,11 +481,11 @@ public class MathUtils
      * @param m The matrix to fill
      */
     public static void infinitePerspective4x4(
-        float fovyDeg, float aspect, float zNear, float m[])
+        double fovyDeg, double aspect, double zNear, double m[])
     {
         setIdentity4x4(m);
-        float fovyRad = (float)Math.toRadians(fovyDeg);
-        float t = (float)Math.tan(0.5 * fovyRad);
+        double fovyRad = Math.toRadians(fovyDeg);
+        double t = Math.tan(0.5 * fovyRad);
         m[0] = 1.0f / (aspect * t);
         m[5] = 1.0f / t;
         m[10] = -1.0f;
@@ -505,11 +505,11 @@ public class MathUtils
      * @param m The matrix to fill
      */
     public static void perspective4x4(
-        float fovyDeg, float aspect, float zNear, float zFar, float m[])
+        double fovyDeg, double aspect, double zNear, double zFar, double m[])
     {
         setIdentity4x4(m);
-        float fovyRad = (float)Math.toRadians(fovyDeg);
-        float t = (float)Math.tan(0.5 * fovyRad);
+        double fovyRad = Math.toRadians(fovyDeg);
+        double t = Math.tan(0.5 * fovyRad);
         m[0] = 1.0f / (aspect * t);
         m[5] = 1.0f / t;
         m[10] = (zFar + zNear) / (zNear - zFar);
@@ -527,9 +527,9 @@ public class MathUtils
      * @param b The second array
      * @return The dot product
      */
-    private static float dot(float a[], float b[])
+    private static double dot(double a[], double b[])
     {
-        float sum = 0;
+        double sum = 0;
         for (int i=0; i<a.length; i++)
         {
             sum += a[i] * b[i];
@@ -548,7 +548,7 @@ public class MathUtils
      * @param result3D The result point
      */
     public static void transformPoint3D(
-        float matrix4x4[], float point3D[], float result3D[])
+        double matrix4x4[], float point3D[], float result3D[])
     {
         Arrays.fill(result3D, 0.0f);
         for (int r=0; r<3; r++)
@@ -556,12 +556,12 @@ public class MathUtils
             for (int c=0; c<3; c++)
             {
                 int index = c * 4 + r;
-                float m = matrix4x4[index];
-                result3D[r] += m * point3D[c];
+                double m = matrix4x4[index];
+                result3D[r] += (float) (m * point3D[c]);
             }
             int index = 3 * 4 + r;
-            float m = matrix4x4[index];
-            result3D[r] += m;
+            double m = matrix4x4[index];
+            result3D[r] += (float) m;
         }
     }
     
@@ -574,7 +574,7 @@ public class MathUtils
      * @param array The array
      * @return The string representation
      */
-    public static String createMatrixString(float array[])
+    public static String createMatrixString(double array[])
     {
         if (array == null)
         {
@@ -600,7 +600,7 @@ public class MathUtils
      * @param cols The number of columns
      * @return The string representation
      */
-    private static String createMatrixString(float array[], int rows, int cols)
+    private static String createMatrixString(double array[], int rows, int cols)
     {
         StringBuilder sb = new StringBuilder();
         for (int r=0; r<rows; r++)
@@ -627,7 +627,7 @@ public class MathUtils
      * @param array The array
      * @return The string representation
      */
-    public static String createFormattedMatrixString(float array[])
+    public static String createFormattedMatrixString(double array[])
     {
         if (array == null)
         {
@@ -657,7 +657,7 @@ public class MathUtils
      * @return The string representation
      */
     private static String createFormattedMatrixString(
-        float array[], int rows, int cols, String format)
+        double array[], int rows, int cols, String format)
     {
         StringBuilder sb = new StringBuilder();
         for (int r = 0; r < rows; r++)

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/MeshModel.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/MeshModel.java
@@ -42,10 +42,10 @@ public interface MeshModel extends NamedModelElement
     List<MeshPrimitiveModel> getMeshPrimitiveModels();
     
     /**
-     * Returns a <b>reference</b> to the default morph target weights, 
-     * or <code>null</code> if no default morph target weights have 
+     * Returns a <b>reference</b> to the default morph target weights,
+     * or <code>null</code> if no default morph target weights have
      * been defined
-     * 
+     *
      * @return The morph target weights
      */
     float[] getWeights();

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/NodeModel.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/NodeModel.java
@@ -88,7 +88,7 @@ public interface NodeModel extends NamedModelElement
      * @throws IllegalArgumentException If the given array does not have
      * a length of 16
      */
-    void setMatrix(float matrix[]);
+    void setMatrix(double matrix[]);
     
     /**
      * Returns a <b>reference</b> to the array storing the matrix of this node.
@@ -97,7 +97,7 @@ public interface NodeModel extends NamedModelElement
      * 
      * @return The matrix
      */
-    float[] getMatrix();
+    double[] getMatrix();
 
     /**
      * Set the translation of this node to be a <b>reference</b> to the given
@@ -107,7 +107,7 @@ public interface NodeModel extends NamedModelElement
      * @throws IllegalArgumentException If the given array does not have
      * a length of 3
      */
-    void setTranslation(float translation[]);
+    void setTranslation(double translation[]);
     
     /**
      * Returns a <b>reference</b> to the array storing the translation of this 
@@ -115,7 +115,7 @@ public interface NodeModel extends NamedModelElement
      * 
      * @return The translation
      */
-    float[] getTranslation();
+    double[] getTranslation();
 
     /**
      * Set the rotation of this node to be a <b>reference</b> to the given
@@ -126,7 +126,7 @@ public interface NodeModel extends NamedModelElement
      * @throws IllegalArgumentException If the given array does not have
      * a length of 4
      */
-    void setRotation(float rotation[]);
+    void setRotation(double rotation[]);
     
     /**
      * Returns a <b>reference</b> to the array storing the rotation of this 
@@ -134,7 +134,7 @@ public interface NodeModel extends NamedModelElement
      * 
      * @return The rotation
      */
-    float[] getRotation();
+    double[] getRotation();
 
     /**
      * Set the scale of this node to be a <b>reference</b> to the given
@@ -144,7 +144,7 @@ public interface NodeModel extends NamedModelElement
      * @throws IllegalArgumentException If the given array does not have
      * a length of 3
      */
-    void setScale(float scale[]);
+    void setScale(double scale[]);
 
     /**
      * Returns a <b>reference</b> to the array storing the scale of this 
@@ -152,7 +152,7 @@ public interface NodeModel extends NamedModelElement
      * 
      * @return The scale
      */
-    float[] getScale();
+    double[] getScale();
     
     /**
      * Set the morph target weights to be a <b>reference</b> to the given
@@ -181,7 +181,7 @@ public interface NodeModel extends NamedModelElement
      * @param result The result array
      * @return The result array
      */
-    float[] computeLocalTransform(float result[]);
+    double[] computeLocalTransform(double result[]);
 
     /**
      * Computes the global transform of this node.<br>
@@ -194,7 +194,7 @@ public interface NodeModel extends NamedModelElement
      * @param result The result array
      * @return The result array
      */
-    float[] computeGlobalTransform(float result[]);
+    double[] computeGlobalTransform(double result[]);
 
     /**
      * Creates a supplier for the global transform matrix of this node 
@@ -208,7 +208,7 @@ public interface NodeModel extends NamedModelElement
      * 
      * @return The supplier
      */
-    Supplier<float[]> createGlobalTransformSupplier();
+    Supplier<double[]> createGlobalTransformSupplier();
 
     /**
      * Creates a supplier for the local transform matrix of this node model.<br>
@@ -221,6 +221,6 @@ public interface NodeModel extends NamedModelElement
      * 
      * @return The supplier
      */
-    Supplier<float[]> createLocalTransformSupplier();
+    Supplier<double[]> createLocalTransformSupplier();
 
 }

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/Optionals.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/Optionals.java
@@ -131,6 +131,22 @@ public class Optionals
         }
         return map.get(key);
     }
+
+    /**
+     * Returns a clone of the given array, or <code>null</code> if the
+     * given array is <code>null</code>
+     *
+     * @param array The array
+     * @return The result
+     */
+    public static double[] clone(double array[])
+    {
+        if (array == null)
+        {
+            return null;
+        }
+        return array.clone();
+    }
     
     /**
      * Returns a clone of the given array, or <code>null</code> if the

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/SkinModel.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/SkinModel.java
@@ -44,7 +44,7 @@ public interface SkinModel extends NamedModelElement
      * @param result The result array
      * @return The result array
      */
-    float[] getBindShapeMatrix(float result[]);
+    double[] getBindShapeMatrix(double result[]);
     
     /**
      * Returns an unmodifiable list containing the joint nodes of the skeleton
@@ -73,14 +73,14 @@ public interface SkinModel extends NamedModelElement
      * Convenience function to obtain the inverse bind matrix for the joint
      * with the given index.<br>
      * <br>
-     * The result will be written to the given array, as a 4x4 matrix in 
+     * The result will be written to the given array, as a 4x4 matrix in
      * column major order. If the given array is <code>null</code> or does
-     * not have a length of 16, then a new array with length 16 will be 
-     * created and returned. 
-     *  
-     * @param index The index of the joint
+     * not have a length of 16, then a new array with length 16 will be
+     * created and returned.
+     *
+     * @param index  The index of the joint
      * @param result The result array
      * @return The result array
      */
-    float[] getInverseBindMatrix(int index, float result[]);
+    double[] getInverseBindMatrix(int index, double result[]);
 }

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/Suppliers.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/Suppliers.java
@@ -35,10 +35,10 @@ import java.util.function.Supplier;
 public class Suppliers
 {
     /**
-     * Create a supplier of a 4x4 matrix that is computed by applying 
+     * Create a supplier of a 4x4 matrix that is computed by applying
      * the given computer to the given object and a 16-element array.<br>
      * <br>
-     * If the given object is <code>null</code>, then the identity 
+     * If the given object is <code>null</code>, then the identity
      * matrix will be supplied.<br>
      * <br>
      * Note: The supplier MAY always return the same array instance.
@@ -50,10 +50,10 @@ public class Suppliers
      * @param computer The computer function
      * @return The supplier
      */
-    public static <T> Supplier<float[]> createTransformSupplier(
-        T object, BiConsumer<T, float[]> computer)
+    public static <T> Supplier<double[]> createTransformSupplier(
+            T object, BiConsumer<T, double[]> computer)
     {
-        float transform[] = new float[16];
+        double transform[] = new double[16];
         if (object == null)
         {
             return () -> 

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/Utils.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/Utils.java
@@ -50,6 +50,24 @@ public class Utils
     }
 
     /**
+     * Validate that the given array is not <code>null</code> and has the
+     * given length. If this is not the case, return a new array with the
+     * specified length.
+     *
+     * @param array The array
+     * @param length The length
+     * @return The array, or a new array with the desired length
+     */
+    public static double[] validate(double array[], int length)
+    {
+        if (array != null && array.length == length)
+        {
+            return array;
+        }
+        return new double[length];
+    }
+
+    /**
      * Private constructor to prevent instantiation
      */
     private Utils()

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/impl/Cameras.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/impl/Cameras.java
@@ -61,10 +61,10 @@ class Cameras
      * @param result The array storing the result
      * @return The result array
      */
-    static float[] computeProjectionMatrix(
-        CameraModel cameraModel, Float aspectRatio, float result[])
+    static double[] computeProjectionMatrix(
+        CameraModel cameraModel, Float aspectRatio, double result[])
     {
-        float localResult[] = Utils.validate(result, 16);
+        double localResult[] = Utils.validate(result, 16);
         
         CameraPerspectiveModel cameraPerspective = 
             cameraModel.getCameraPerspectiveModel();

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/impl/DefaultCameraModel.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/impl/DefaultCameraModel.java
@@ -93,16 +93,16 @@ public final class DefaultCameraModel extends AbstractNamedModelElement
     }
 
     @Override
-    public float[] computeProjectionMatrix(float result[], Float aspectRatio)
+    public double[] computeProjectionMatrix(double result[], Float aspectRatio)
     {
         return Cameras.computeProjectionMatrix(this, aspectRatio, result);
     }
     
     @Override
-    public Supplier<float[]> createProjectionMatrixSupplier(
+    public Supplier<double[]> createProjectionMatrixSupplier(
         DoubleSupplier aspectRatioSupplier)
     {
-        return Suppliers.createTransformSupplier(this, (c, t) -> 
+        return Suppliers.createTransformSupplier(this, (c, t) ->
         {
             Float aspectRatio = null;
             if (aspectRatioSupplier != null)

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/impl/DefaultNodeModel.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/impl/DefaultNodeModel.java
@@ -49,14 +49,14 @@ public class DefaultNodeModel extends AbstractNamedModelElement
     /**
      * A thread-local, temporary 16-element matrix
      */
-    private static final ThreadLocal<float[]> TEMP_MATRIX_4x4_IN_LOCAL =
-        ThreadLocal.withInitial(() -> new float[16]);
+    private static final ThreadLocal<double[]> TEMP_MATRIX_4x4_IN_LOCAL =
+        ThreadLocal.withInitial(() -> new double[16]);
     
     /**
      * A thread-local, temporary 16-element matrix
      */
-    private static final ThreadLocal<float[]> TEMP_MATRIX_4x4_IN_GLOBAL =
-        ThreadLocal.withInitial(() -> new float[16]);
+    private static final ThreadLocal<double[]> TEMP_MATRIX_4x4_IN_GLOBAL =
+        ThreadLocal.withInitial(() -> new double[16]);
     
     /**
      * The parent of this node. This is <code>null</code> for the root node.
@@ -86,22 +86,22 @@ public class DefaultNodeModel extends AbstractNamedModelElement
     /**
      * The local transform matrix
      */
-    private float matrix[];
+    private double matrix[];
     
     /**
      * The translation
      */
-    private float translation[];
+    private double translation[];
     
     /**
      * The rotation
      */
-    private float rotation[];
+    private double rotation[];
     
     /**
      * The scale
      */
-    private float scale[];
+    private double scale[];
 
     /**
      * The weights
@@ -222,49 +222,49 @@ public class DefaultNodeModel extends AbstractNamedModelElement
     }
     
     @Override
-    public void setMatrix(float[] matrix)
+    public void setMatrix(double[] matrix)
     {
         this.matrix = check(matrix, 16);
     }
     
     @Override
-    public float[] getMatrix()
+    public double[] getMatrix()
     {
         return matrix;
     }
 
     @Override
-    public void setTranslation(float[] translation)
+    public void setTranslation(double[] translation)
     {
         this.translation = check(translation, 3);
     }
 
     @Override
-    public float[] getTranslation()
+    public double[] getTranslation()
     {
         return translation;
     }
 
     @Override
-    public void setRotation(float[] rotation)
+    public void setRotation(double[] rotation)
     {
         this.rotation = check(rotation, 4);
     }
 
     @Override
-    public float[] getRotation()
+    public double[] getRotation()
     {
         return rotation;
     }
 
     @Override
-    public void setScale(float[] scale)
+    public void setScale(double[] scale)
     {
         this.scale = check(scale, 3);
     }
 
     @Override
-    public float[] getScale()
+    public double[] getScale()
     {
         return scale;
     }
@@ -283,28 +283,28 @@ public class DefaultNodeModel extends AbstractNamedModelElement
     
     
     @Override
-    public float[] computeLocalTransform(float result[])
+    public double[] computeLocalTransform(double result[])
     {
         return computeLocalTransform(this, result);
     }
 
     @Override
-    public float[] computeGlobalTransform(float result[])
+    public double[] computeGlobalTransform(double result[])
     {
         return computeGlobalTransform(this, result);
     }
     
     @Override
-    public Supplier<float[]> createGlobalTransformSupplier()
+    public Supplier<double[]> createGlobalTransformSupplier()
     {
-        return Suppliers.createTransformSupplier(this, 
+        return Suppliers.createTransformSupplier(this,
             NodeModel::computeGlobalTransform);
     }
     
     @Override
-    public Supplier<float[]> createLocalTransformSupplier()
+    public Supplier<double[]> createLocalTransformSupplier()
     {
-        return Suppliers.createTransformSupplier(this, 
+        return Suppliers.createTransformSupplier(this,
             NodeModel::computeLocalTransform);
     }
 
@@ -324,13 +324,13 @@ public class DefaultNodeModel extends AbstractNamedModelElement
      * @param result The result array
      * @return The result array
      */
-    public static float[] computeLocalTransform(
-        NodeModel nodeModel, float result[])
+    public static double[] computeLocalTransform(
+        NodeModel nodeModel, double result[])
     {
-        float localResult[] = Utils.validate(result, 16);
+        double localResult[] = Utils.validate(result, 16);
         if (nodeModel.getMatrix() != null)
         {
-            float m[] = nodeModel.getMatrix();
+            double m[] = nodeModel.getMatrix();
             System.arraycopy(m, 0, localResult, 0, m.length);
             return localResult;
         }
@@ -338,22 +338,22 @@ public class DefaultNodeModel extends AbstractNamedModelElement
         MathUtils.setIdentity4x4(localResult);
         if (nodeModel.getTranslation() != null)
         {
-            float t[] = nodeModel.getTranslation();
+            double t[] = nodeModel.getTranslation();
             localResult[12] = t[0]; 
             localResult[13] = t[1]; 
             localResult[14] = t[2]; 
         }
         if (nodeModel.getRotation() != null)
         {
-            float q[] = nodeModel.getRotation();
-            float m[] = TEMP_MATRIX_4x4_IN_LOCAL.get();
+            double q[] = nodeModel.getRotation();
+            double m[] = TEMP_MATRIX_4x4_IN_LOCAL.get();
             MathUtils.quaternionToMatrix4x4(q, m);
             MathUtils.mul4x4(localResult, m, localResult);
         }
         if (nodeModel.getScale() != null)
         {
-            float s[] = nodeModel.getScale();
-            float m[] = TEMP_MATRIX_4x4_IN_LOCAL.get();
+            double s[] = nodeModel.getScale();
+            double m[] = TEMP_MATRIX_4x4_IN_LOCAL.get();
             MathUtils.setIdentity4x4(m);
             m[ 0] = s[0];
             m[ 5] = s[1];
@@ -374,11 +374,11 @@ public class DefaultNodeModel extends AbstractNamedModelElement
      * @param result The result
      * @return The result
      */
-    private static float[] computeGlobalTransform(
-        NodeModel nodeModel, float result[])
+    private static double[] computeGlobalTransform(
+        NodeModel nodeModel, double result[])
     {
-        float localResult[] = Utils.validate(result, 16);
-        float tempLocalTransform[] = TEMP_MATRIX_4x4_IN_GLOBAL.get();
+        double localResult[] = Utils.validate(result, 16);
+        double tempLocalTransform[] = TEMP_MATRIX_4x4_IN_GLOBAL.get();
         NodeModel currentNode = nodeModel;
         MathUtils.setIdentity4x4(localResult);
         while (currentNode != null)
@@ -404,7 +404,7 @@ public class DefaultNodeModel extends AbstractNamedModelElement
      * @throws IllegalArgumentException If the given array does not have
      * the expected length
      */
-    private static float[] check(float array[], int expectedLength)
+    private static double[] check(double array[], int expectedLength)
     {
         if (array == null)
         {

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/impl/DefaultSkinModel.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/impl/DefaultSkinModel.java
@@ -48,7 +48,7 @@ public final class DefaultSkinModel extends AbstractNamedModelElement
     /**
      * The bind shape matrix
      */
-    private float bindShapeMatrix[];
+    private double bindShapeMatrix[];
     
     /**
      * The joint nodes
@@ -81,7 +81,7 @@ public final class DefaultSkinModel extends AbstractNamedModelElement
      * will be stored. If it is <code>null</code>, a new array will be 
      * created, which represents the identity matrix.
      */
-    public void setBindShapeMatrix(float[] bindShapeMatrix)
+    public void setBindShapeMatrix(double[] bindShapeMatrix)
     {
         if (bindShapeMatrix == null)
         {
@@ -127,9 +127,9 @@ public final class DefaultSkinModel extends AbstractNamedModelElement
     
 
     @Override
-    public float[] getBindShapeMatrix(float[] result)
+    public double[] getBindShapeMatrix(double[] result)
     {
-        float localResult[] = Utils.validate(result, 16);
+        double localResult[] = Utils.validate(result, 16);
         System.arraycopy(bindShapeMatrix, 0, localResult, 0, 16);
         return localResult;
     }
@@ -154,9 +154,9 @@ public final class DefaultSkinModel extends AbstractNamedModelElement
     }
 
     @Override
-    public float[] getInverseBindMatrix(int index, float[] result)
+    public double[] getInverseBindMatrix(int index, double[] result)
     {
-        float localResult[] = Utils.validate(result, 16);
+        double localResult[] = Utils.validate(result, 16);
         AccessorFloatData inverseBindMatricesData = 
             AccessorDatas.createFloat(inverseBindMatrices);
         for (int j = 0; j < 16; j++)

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/structure/GltfModelStructures.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/structure/GltfModelStructures.java
@@ -706,10 +706,10 @@ public class GltfModelStructures
             DefaultCameraModel targetCamera = cameraModelsMap.get(sourceCamera);
             targetNodeModel.setCameraModel(targetCamera);
 
-            float matrix[] = sourceNodeModel.getMatrix();
-            float translation[] = sourceNodeModel.getTranslation();
-            float rotation[] = sourceNodeModel.getRotation();
-            float scale[] = sourceNodeModel.getScale();
+            double matrix[] = sourceNodeModel.getMatrix();
+            double translation[] = sourceNodeModel.getTranslation();
+            double rotation[] = sourceNodeModel.getRotation();
+            double scale[] = sourceNodeModel.getScale();
             float weights[] = sourceNodeModel.getWeights();
             
             targetNodeModel.setMatrix(Optionals.clone(matrix));

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/v1/GltfModelCreatorV1.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/v1/GltfModelCreatorV1.java
@@ -473,7 +473,7 @@ public class GltfModelCreatorV1
         for (Entry<String, Skin> entry : skins.entrySet())
         {
             Skin skin = entry.getValue();
-            float[] bindShapeMatrix = skin.getBindShapeMatrix();
+            double[] bindShapeMatrix = skin.getBindShapeMatrix();
             DefaultSkinModel skinModel = new DefaultSkinModel();
             skinModel.setBindShapeMatrix(bindShapeMatrix);
             gltfModel.addSkinModel(skinModel);
@@ -1007,11 +1007,11 @@ public class GltfModelCreatorV1
                     get("cameras", cameraId, gltfModel::getCameraModel);
                 nodeModel.setCameraModel(cameraModel);
             }
-            
-            float matrix[] = node.getMatrix();
-            float translation[] = node.getTranslation();
-            float rotation[] = node.getRotation();
-            float scale[] = node.getScale();
+
+            double matrix[] = node.getMatrix();
+            double translation[] = node.getTranslation();
+            double rotation[] = node.getRotation();
+            double scale[] = node.getScale();
             nodeModel.setMatrix(Optionals.clone(matrix));
             nodeModel.setTranslation(Optionals.clone(translation));
             nodeModel.setRotation(Optionals.clone(rotation));

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfCreatorV2.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfCreatorV2.java
@@ -1083,12 +1083,12 @@ public class GltfCreatorV2
         }
         return indices;
     }
-    
-    
+
+
     /**
      * Returns a new list containing the elements of the given array,
      * or <code>null</code> if the given array is <code>null</code>
-     * 
+     *
      * @param array The array
      * @return The list
      */
@@ -1100,6 +1100,28 @@ public class GltfCreatorV2
         }
         List<Float> list = new ArrayList<Float>();
         for (float f : array)
+        {
+            list.add(f);
+        }
+        return list;
+    }
+    
+    
+    /**
+     * Returns a new list containing the elements of the given array,
+     * or <code>null</code> if the given array is <code>null</code>
+     * 
+     * @param array The array
+     * @return The list
+     */
+    private static List<Double> toList(double array[])
+    {
+        if (array == null)
+        {
+            return null;
+        }
+        List<Double> list = new ArrayList<Double>();
+        for (double f : array)
         {
             list.add(f);
         }

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfCreatorV2.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfCreatorV2.java
@@ -1105,26 +1105,4 @@ public class GltfCreatorV2
         }
         return list;
     }
-    
-    
-    /**
-     * Returns a new list containing the elements of the given array,
-     * or <code>null</code> if the given array is <code>null</code>
-     * 
-     * @param array The array
-     * @return The list
-     */
-    private static List<Double> toList(double array[])
-    {
-        if (array == null)
-        {
-            return null;
-        }
-        List<Double> list = new ArrayList<Double>();
-        for (double f : array)
-        {
-            list.add(f);
-        }
-        return list;
-    }
 }

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfModelCreatorV2.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfModelCreatorV2.java
@@ -905,7 +905,7 @@ public class GltfModelCreatorV2
                     createMeshPrimitiveModel(meshPrimitive);
                 meshModel.addMeshPrimitiveModel(meshPrimitiveModel);
             }
-            meshModel.setWeights(toArray(mesh.getWeights()));
+            meshModel.setWeights(toFloatArray(mesh.getWeights()));
         }
     }
     
@@ -1011,17 +1011,17 @@ public class GltfModelCreatorV2
                 CameraModel cameraModel = gltfModel.getCameraModel(cameraIndex);
                 nodeModel.setCameraModel(cameraModel);
             }
-            
-            float matrix[] = node.getMatrix();
-            float translation[] = node.getTranslation();
-            float rotation[] = node.getRotation();
-            float scale[] = node.getScale();
+
+            double matrix[] = node.getMatrix();
+            double translation[] = node.getTranslation();
+            double rotation[] = node.getRotation();
+            double scale[] = node.getScale();
             nodeModel.setMatrix(Optionals.clone(matrix));
             nodeModel.setTranslation(Optionals.clone(translation));
             nodeModel.setRotation(Optionals.clone(rotation));
             nodeModel.setScale(Optionals.clone(scale));
             
-            nodeModel.setWeights(toArray(node.getWeights()));
+            nodeModel.setWeights(toFloatArray(node.getWeights()));
         }
     }
     
@@ -1336,11 +1336,11 @@ public class GltfModelCreatorV2
     /**
      * Returns an array containing the float representations of the given
      * numbers, or <code>null</code> if the given list is <code>null</code>.
-     * 
+     *
      * @param numbers The numbers
      * @return The array
      */
-    private static float[] toArray(List<? extends Number> numbers)
+    private static float[] toFloatArray(List<? extends Number> numbers)
     {
         if (numbers == null)
         {
@@ -1350,6 +1350,27 @@ public class GltfModelCreatorV2
         for (int j = 0; j < numbers.size(); j++)
         {
             array[j] = numbers.get(j).floatValue();
+        }
+        return array;
+    }
+
+    /**
+     * Returns an array containing the float representations of the given
+     * numbers, or <code>null</code> if the given list is <code>null</code>.
+     * 
+     * @param numbers The numbers
+     * @return The array
+     */
+    private static double[] toDoubleArray(List<? extends Number> numbers)
+    {
+        if (numbers == null)
+        {
+            return null;
+        }
+        double array[] = new double[numbers.size()];
+        for (int j = 0; j < numbers.size(); j++)
+        {
+            array[j] = numbers.get(j).doubleValue();
         }
         return array;
     }

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfModelCreatorV2.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfModelCreatorV2.java
@@ -905,7 +905,7 @@ public class GltfModelCreatorV2
                     createMeshPrimitiveModel(meshPrimitive);
                 meshModel.addMeshPrimitiveModel(meshPrimitiveModel);
             }
-            meshModel.setWeights(toFloatArray(mesh.getWeights()));
+            meshModel.setWeights(toArray(mesh.getWeights()));
         }
     }
     
@@ -1021,7 +1021,7 @@ public class GltfModelCreatorV2
             nodeModel.setRotation(Optionals.clone(rotation));
             nodeModel.setScale(Optionals.clone(scale));
             
-            nodeModel.setWeights(toFloatArray(node.getWeights()));
+            nodeModel.setWeights(toArray(node.getWeights()));
         }
     }
     
@@ -1340,7 +1340,7 @@ public class GltfModelCreatorV2
      * @param numbers The numbers
      * @return The array
      */
-    private static float[] toFloatArray(List<? extends Number> numbers)
+    private static float[] toArray(List<? extends Number> numbers)
     {
         if (numbers == null)
         {
@@ -1350,27 +1350,6 @@ public class GltfModelCreatorV2
         for (int j = 0; j < numbers.size(); j++)
         {
             array[j] = numbers.get(j).floatValue();
-        }
-        return array;
-    }
-
-    /**
-     * Returns an array containing the float representations of the given
-     * numbers, or <code>null</code> if the given list is <code>null</code>.
-     * 
-     * @param numbers The numbers
-     * @return The array
-     */
-    private static double[] toDoubleArray(List<? extends Number> numbers)
-    {
-        if (numbers == null)
-        {
-            return null;
-        }
-        double array[] = new double[numbers.size()];
-        for (int j = 0; j < numbers.size(); j++)
-        {
-            array[j] = numbers.get(j).doubleValue();
         }
         return array;
     }

--- a/jgltf-viewer/src/main/java/de/javagl/jgltf/viewer/AbstractGltfViewer.java
+++ b/jgltf-viewer/src/main/java/de/javagl/jgltf/viewer/AbstractGltfViewer.java
@@ -64,12 +64,12 @@ public abstract class AbstractGltfViewer<C> implements GltfViewer<C>
      * {@link RenderedGltfModel} constructor, and eventually provide the data 
      * for the uniforms that have the <code>VIEWPORT</code> semantic.
      */
-    private final Supplier<float[]> viewportSupplier = new Supplier<float[]>()
+    private final Supplier<double[]> viewportSupplier = new Supplier<double[]>()
     {
-        private final float viewport[] = new float[4];
+        private final double viewport[] = new double[4];
 
         @Override
-        public float[] get()
+        public double[] get()
         {
             viewport[0] = 0;
             viewport[1] = 0;

--- a/jgltf-viewer/src/main/java/de/javagl/jgltf/viewer/CesiumRtcUtils.java
+++ b/jgltf-viewer/src/main/java/de/javagl/jgltf/viewer/CesiumRtcUtils.java
@@ -77,11 +77,11 @@ class CesiumRtcUtils
      * @param rtcCenter The RTC center
      * @return The supplier
      */
-    static Supplier<float[]> createCesiumRtcModelViewMatrixSupplier(
-        NodeModel nodeModel, Supplier<float[]> viewMatrixSupplier, 
-        float rtcCenter[])
+    static Supplier<double[]> createCesiumRtcModelViewMatrixSupplier(
+        NodeModel nodeModel, Supplier<double[]> viewMatrixSupplier,
+        double rtcCenter[])
     {
-        Supplier<float[]> modelMatrixSupplier = 
+        Supplier<double[]> modelMatrixSupplier =
             nodeModel.createGlobalTransformSupplier();
         return MatrixOps
             .create4x4()
@@ -102,7 +102,7 @@ class CesiumRtcUtils
      * @param gltfModel The {@link GltfModel}
      * @return The RTC center
      */
-    static float[] extractRtcCenterFromModel(GltfModel gltfModel)
+    static double[] extractRtcCenterFromModel(GltfModel gltfModel)
     {
         Map<String, Object> extensions = gltfModel.getExtensions();
         if (extensions == null) 
@@ -121,7 +121,7 @@ class CesiumRtcUtils
      * @param extensionObject The extension object
      * @return The RTC center
      */
-    private static float[] extractRtcCenterFromExtensionObbject(
+    private static double[] extractRtcCenterFromExtensionObbject(
         Object extensionObject)
     {
         // NOTE: This is very pragmatic and involves some manual fiddling.
@@ -156,7 +156,7 @@ class CesiumRtcUtils
                 + "have size 3, but has " + list.size());
             return null;
         }
-        float result[] = new float[3];
+        double result[] = new double[3];
         for (int i = 0; i < list.size(); i++)
         {
             Object value = list.get(i);
@@ -168,7 +168,7 @@ class CesiumRtcUtils
                 return null;
             }
             Number number = (Number) value;
-            result[i] = number.floatValue();
+            result[i] = number.doubleValue();
         }
         return result;
     }

--- a/jgltf-viewer/src/main/java/de/javagl/jgltf/viewer/DefaultRenderedCamera.java
+++ b/jgltf-viewer/src/main/java/de/javagl/jgltf/viewer/DefaultRenderedCamera.java
@@ -52,12 +52,12 @@ public class DefaultRenderedCamera implements RenderedCamera
     /**
      * The view matrix
      */
-    private final float viewMatrix[];
+    private final double viewMatrix[];
     
     /**
      * The projection matrix
      */
-    private final float projectionMatrix[];
+    private final double projectionMatrix[];
     
     /**
      * An optional supplier for the aspect ratio. If this is <code>null</code>, 
@@ -89,12 +89,12 @@ public class DefaultRenderedCamera implements RenderedCamera
             cameraModel, "The cameraModel may not be null");
         this.aspectRatioSupplier = aspectRatioSupplier;
         
-        this.viewMatrix = new float[16];
-        this.projectionMatrix = new float[16];
+        this.viewMatrix = new double[16];
+        this.projectionMatrix = new double[16];
     }
 
     @Override
-    public float[] getViewMatrix()
+    public double[] getViewMatrix()
     {
         nodeModel.computeGlobalTransform(viewMatrix);
         MathUtils.invert4x4(viewMatrix, viewMatrix);
@@ -102,7 +102,7 @@ public class DefaultRenderedCamera implements RenderedCamera
     }
 
     @Override
-    public float[] getProjectionMatrix()
+    public double[] getProjectionMatrix()
     {
         Float aspectRatio = null;
         if (aspectRatioSupplier != null)

--- a/jgltf-viewer/src/main/java/de/javagl/jgltf/viewer/DefaultRenderedGltfModel.java
+++ b/jgltf-viewer/src/main/java/de/javagl/jgltf/viewer/DefaultRenderedGltfModel.java
@@ -147,7 +147,7 @@ class DefaultRenderedGltfModel implements RenderedGltfModel
         Objects.requireNonNull(viewConfiguration,
             "The viewConfiguration may not be null");
 
-        float rtcCenter[] = CesiumRtcUtils.extractRtcCenterFromModel(gltfModel);
+        double rtcCenter[] = CesiumRtcUtils.extractRtcCenterFromModel(gltfModel);
         if (rtcCenter != null)
         {
             // NOTE: The RTC center is not really APPLIED here during 

--- a/jgltf-viewer/src/main/java/de/javagl/jgltf/viewer/MatrixOps.java
+++ b/jgltf-viewer/src/main/java/de/javagl/jgltf/viewer/MatrixOps.java
@@ -56,7 +56,7 @@ class MatrixOps
     /**
      * The supplier that provides the input matrix
      */
-    private final Supplier<float[]> inputSupplier;
+    private final Supplier<double[]> inputSupplier;
     
     /**
      * The chain of functions that will be applied. Starting with the
@@ -65,7 +65,7 @@ class MatrixOps
      * The result of the final function will be returned by the 
      * supplier that is created with {@link #build()}.
      */
-    private final List<Function<float[], float[]>> functions;
+    private final List<Function<double[], double[]>> functions;
     
     /**
      * Create a builder for matrix operations that obtains its initial
@@ -74,7 +74,7 @@ class MatrixOps
      * @param inputSupplier The input matrix supplier
      * @return The builder
      */
-    static MatrixOps create4x4(Supplier<float[]> inputSupplier)
+    static MatrixOps create4x4(Supplier<double[]> inputSupplier)
     {
         return new MatrixOps(inputSupplier);
     }
@@ -95,9 +95,9 @@ class MatrixOps
      * 
      * @return The supplier
      */
-    private static Supplier<float[]> createIdentitySupplier4x4()
+    private static Supplier<double[]> createIdentitySupplier4x4()
     {
-        float matrix[] = new float[16];
+        double matrix[] = new double[16];
         return () ->
         {
             MathUtils.setIdentity4x4(matrix);
@@ -110,10 +110,10 @@ class MatrixOps
      * 
      * @param inputSupplier The supplier of the input matrix
      */
-    private MatrixOps(Supplier<float[]> inputSupplier)
+    private MatrixOps(Supplier<double[]> inputSupplier)
     {
         this.inputSupplier = inputSupplier; 
-        this.functions = new ArrayList<Function<float[], float[]>>();
+        this.functions = new ArrayList<Function<double[], double[]>>();
     }
     
     /**
@@ -123,9 +123,9 @@ class MatrixOps
      * @param operandSupplier The supplier of the operand
      * @return This builder
      */
-    MatrixOps multiply4x4(Supplier<float[]> operandSupplier)
+    MatrixOps multiply4x4(Supplier<double[]> operandSupplier)
     {
-        float result[] = new float[16];
+        double result[] = new double[16];
         functions.add(named("multiply4x4", input -> 
         {
             MathUtils.mul4x4(input, operandSupplier.get(), result);
@@ -141,7 +141,7 @@ class MatrixOps
      */
     MatrixOps invert4x4()
     {
-        float result[] = new float[16];
+        double result[] = new double[16];
         functions.add(named("invert4x4", input -> 
         {
             MathUtils.invert4x4(input, result);
@@ -157,7 +157,7 @@ class MatrixOps
      */
     MatrixOps invert3x3()
     {
-        float result[] = new float[9];
+        double result[] = new double[9];
         functions.add(named("invert3x4", input -> 
         {
             MathUtils.invert3x3(input, result);
@@ -173,7 +173,7 @@ class MatrixOps
      */
     MatrixOps transpose4x4()
     {
-        float result[] = new float[16];
+        double result[] = new double[16];
         functions.add(named("transpose4x4", input -> 
         {
             MathUtils.transpose4x4(input, result);
@@ -190,7 +190,7 @@ class MatrixOps
      */
     MatrixOps getRotationScale()
     {
-        float result[] = new float[9];
+        double result[] = new double[9];
         functions.add(named("getRotationScale", input -> 
         {
             MathUtils.getRotationScale(input, result);
@@ -207,9 +207,9 @@ class MatrixOps
      * @param z The z-translation
      * @return This builder
      */
-    MatrixOps translate(float x, float y, float z)
+    MatrixOps translate(double x, double y, double z)
     {
-        float result[] = new float[16];
+        double result[] = new double[16];
         functions.add(named("translate", input -> 
         {
             MathUtils.translate(input, x, y, z, result);
@@ -275,12 +275,12 @@ class MatrixOps
      * 
      * @return The supplier
      */
-    Supplier<float[]> build()
+    Supplier<double[]> build()
     {
         return () ->
         {
-            float current[] = inputSupplier.get();
-            for (Function<float[], float[]> function : functions)
+            double current[] = inputSupplier.get();
+            for (Function<double[], double[]> function : functions)
             {
                 current = function.apply(current);
                 if (logger.isLoggable(Level.FINEST))

--- a/jgltf-viewer/src/main/java/de/javagl/jgltf/viewer/RenderedCamera.java
+++ b/jgltf-viewer/src/main/java/de/javagl/jgltf/viewer/RenderedCamera.java
@@ -32,15 +32,15 @@ package de.javagl.jgltf.viewer;
 public interface RenderedCamera
 {
     /**
-     * The view matrix of this camera, as a float array with 16 elements, 
+     * The view matrix of this camera, as a float array with 16 elements,
      * representing the 4x4 matrix in column-major order.<br>
      * <br>
      * The returned matrix will not be stored or modified. So the supplier
      * may always return the same matrix instance.
-     * 
+     *
      * @return The view matrix
      */
-    float[] getViewMatrix();
+    double[] getViewMatrix();
 
     /**
      * The projection matrix of this camera, as a float array with 16 elements,
@@ -48,8 +48,8 @@ public interface RenderedCamera
      * <br>
      * The returned matrix will not be stored or modified. So the supplier
      * may always return the same matrix instance.
-     * 
+     *
      * @return The projection matrix
      */
-    float[] getProjectionMatrix();
+    double[] getProjectionMatrix();
 }

--- a/jgltf-viewer/src/main/java/de/javagl/jgltf/viewer/UniformGetterFactory.java
+++ b/jgltf-viewer/src/main/java/de/javagl/jgltf/viewer/UniformGetterFactory.java
@@ -57,18 +57,18 @@ class UniformGetterFactory
     /**
      * A supplier for the view matrix.  
      */
-    private final Supplier<float[]> viewMatrixSupplier;
+    private final Supplier<double[]> viewMatrixSupplier;
     
     /**
      * A supplier for the projection matrix.
      */
-    private final Supplier<float[]> projectionMatrixSupplier;
+    private final Supplier<double[]> projectionMatrixSupplier;
     
     /**
      * A supplier that supplies the viewport, as 4 float elements, 
      * [x, y, width, height]
      */
-    private final Supplier<float[]> viewportSupplier;
+    private final Supplier<double[]> viewportSupplier;
     
     /**
      * The set of uniform names for which a <code>null</code> value 
@@ -79,7 +79,7 @@ class UniformGetterFactory
     /**
      * The RTC center point for the CESIUM_RTC extension
      */
-    private float rtcCenter[];
+    private double rtcCenter[];
     
     /**
      * Creates a new instance
@@ -95,10 +95,10 @@ class UniformGetterFactory
      * extension
      */
     public UniformGetterFactory(
-        Supplier<float[]> viewportSupplier,
-        Supplier<float[]> viewMatrixSupplier,
-        Supplier<float[]> projectionMatrixSupplier,
-        float rtcCenter[])
+        Supplier<double[]> viewportSupplier,
+        Supplier<double[]> viewMatrixSupplier,
+        Supplier<double[]> projectionMatrixSupplier,
+        double rtcCenter[])
     {
         this.viewportSupplier = Objects.requireNonNull(viewportSupplier, 
             "The viewportSupplier may not be null");
@@ -107,7 +107,7 @@ class UniformGetterFactory
         this.projectionMatrixSupplier = 
             Objects.requireNonNull(projectionMatrixSupplier, 
                 "The projectionMatrixSupplier may not be null");
-        this.rtcCenter = rtcCenter == null ? new float[3] : rtcCenter.clone();
+        this.rtcCenter = rtcCenter == null ? new double[3] : rtcCenter.clone();
         this.reportedNullUniformNames = new LinkedHashSet<String>();
     }
     
@@ -233,7 +233,7 @@ class UniformGetterFactory
      *   </li>
      * </ul>
      * The actual contents of these joint matrices is computed from the
-     * {@link SkinModel#getBindShapeMatrix(float[]) bind shape matrix}, the
+     * {@link SkinModel#getBindShapeMatrix(double[]) bind shape matrix}, the
      * {@link SkinModel#getInverseBindMatrices() inverse bind matrices} and 
      * the global transform of the given node and the joint node. See the glTF 
      * specification for details.<br>
@@ -308,7 +308,7 @@ class UniformGetterFactory
             
             case MODELVIEW:
             {
-                Supplier<float[]> modelMatrixSupplier = 
+                Supplier<double[]> modelMatrixSupplier =
                     nodeModel.createGlobalTransformSupplier();
                 return MatrixOps
                     .create4x4(viewMatrixSupplier)
@@ -319,7 +319,7 @@ class UniformGetterFactory
             
             case MODELVIEWPROJECTION:
             {
-                Supplier<float[]> modelMatrixSupplier = 
+                Supplier<double[]> modelMatrixSupplier =
                     nodeModel.createGlobalTransformSupplier();
                 return MatrixOps
                     .create4x4(projectionMatrixSupplier)
@@ -331,7 +331,7 @@ class UniformGetterFactory
             
             case MODELINVERSE:
             {
-                Supplier<float[]> modelMatrixSupplier = 
+                Supplier<double[]> modelMatrixSupplier =
                     nodeModel.createGlobalTransformSupplier();
                 return MatrixOps
                     .create4x4(modelMatrixSupplier)
@@ -351,7 +351,7 @@ class UniformGetterFactory
 
             case MODELVIEWINVERSE:
             {
-                Supplier<float[]> modelMatrixSupplier = 
+                Supplier<double[]> modelMatrixSupplier =
                     nodeModel.createGlobalTransformSupplier();
                 return MatrixOps
                     .create4x4(viewMatrixSupplier)
@@ -372,7 +372,7 @@ class UniformGetterFactory
             
             case MODELVIEWPROJECTIONINVERSE:
             {
-                Supplier<float[]> modelMatrixSupplier = 
+                Supplier<double[]> modelMatrixSupplier =
                     nodeModel.createGlobalTransformSupplier();
                 return MatrixOps
                     .create4x4(projectionMatrixSupplier)
@@ -385,7 +385,7 @@ class UniformGetterFactory
 
             case MODELINVERSETRANSPOSE:
             {
-                Supplier<float[]> modelMatrixSupplier = 
+                Supplier<double[]> modelMatrixSupplier =
                     nodeModel.createGlobalTransformSupplier();
                 return MatrixOps
                     .create4x4(modelMatrixSupplier)
@@ -398,7 +398,7 @@ class UniformGetterFactory
             
             case MODELVIEWINVERSETRANSPOSE:
             {
-                Supplier<float[]> modelMatrixSupplier = 
+                Supplier<double[]> modelMatrixSupplier =
                     nodeModel.createGlobalTransformSupplier();
                 return MatrixOps
                     .create4x4(viewMatrixSupplier)
@@ -435,15 +435,15 @@ class UniformGetterFactory
      * @param nodeModel The {@link NodeModel} 
      * @return The supplier
      */
-    private static Supplier<float[]> createJointMatrixSupplier(
+    private static Supplier<double[]> createJointMatrixSupplier(
         NodeModel nodeModel)
     {
         SkinModel skinModel = nodeModel.getSkinModel();
 
         // Create the supplier for the bind shape matrix (or a supplier
         // of the identity matrix, if the bind shape matrix is null)
-        float bindShapeMatrix[] = skinModel.getBindShapeMatrix(null);
-        Supplier<float[]> bindShapeMatrixSupplier = 
+        double bindShapeMatrix[] = skinModel.getBindShapeMatrix(null);
+        Supplier<double[]> bindShapeMatrixSupplier =
             MatrixOps.create4x4(() -> bindShapeMatrix)
             .log("bindShapeMatrix", Level.FINE)
             .build();
@@ -454,18 +454,18 @@ class UniformGetterFactory
         // Create one supplier for each inverse bind matrix. Each of them will 
         // extract one element of the inverse bind matrix accessor data and 
         // provide it as a single float[16] array, representing a 4x4 matrix
-        List<Supplier<float[]>> inverseBindMatrixSuppliers =
-            new ArrayList<Supplier<float[]>>();
+        List<Supplier<double[]>> inverseBindMatrixSuppliers =
+            new ArrayList<Supplier<double[]>>();
         for (int i = 0; i < numJoints; i++)
         {
             final int currentJointIndex = i;
-            float inverseBindMatrix[] = new float[16];
-            Supplier<float[]> inverseBindMatrixSupplier = () ->
+            double inverseBindMatrix[] = new double[16];
+            Supplier<double[]> inverseBindMatrixSupplier = () ->
             {
                 return skinModel.getInverseBindMatrix(
                     currentJointIndex, inverseBindMatrix);
             };
-            Supplier<float[]> loggingInverseBindMatrixSupplier =
+            Supplier<double[]> loggingInverseBindMatrixSupplier =
                 MatrixOps.create4x4(inverseBindMatrixSupplier)
                     .log("inverseBindMatrix "+i, Level.FINE)
                     .build();
@@ -479,16 +479,16 @@ class UniformGetterFactory
         //     [globalTransformOfJointNode] *
         //     [inverseBindMatrix(j)] *
         //     [bindShapeMatrix]
-        List<Supplier<float[]>> jointMatrixSuppliers = 
-            new ArrayList<Supplier<float[]>>();
+        List<Supplier<double[]>> jointMatrixSuppliers =
+            new ArrayList<Supplier<double[]>>();
         for (int j = 0; j < numJoints; j++)
         {
             NodeModel jointNodeModel = joints.get(j);
             
-            Supplier<float[]> inverseBindMatrixSupplier = 
+            Supplier<double[]> inverseBindMatrixSupplier =
                 inverseBindMatrixSuppliers.get(j);
             
-            Supplier<float[]> jointMatrixSupplier = MatrixOps
+            Supplier<double[]> jointMatrixSupplier = MatrixOps
                 .create4x4(nodeModel.createGlobalTransformSupplier())
                 .invert4x4()
                 .multiply4x4(jointNodeModel.createGlobalTransformSupplier())
@@ -502,14 +502,14 @@ class UniformGetterFactory
         // Create a supplier for the joint matrices, which combines the
         // joint matrices of the individual joint matrix suppliers 
         // into one array
-        float jointMatrices[] = new float[jointMatrixSuppliers.size() * 16];
+        double jointMatrices[] = new double[jointMatrixSuppliers.size() * 16];
         return () -> 
         {
             for (int i=0; i<jointMatrixSuppliers.size(); i++)
             {
-                Supplier<float[]> jointMatrixSupplier = 
+                Supplier<double[]> jointMatrixSupplier =
                     jointMatrixSuppliers.get(i);
-                float[] jointMatrix = jointMatrixSupplier.get();
+                double[] jointMatrix = jointMatrixSupplier.get();
                 System.arraycopy(jointMatrix, 0, jointMatrices, i * 16, 16);
             }
             return jointMatrices;

--- a/jgltf-viewer/src/main/java/de/javagl/jgltf/viewer/ViewConfiguration.java
+++ b/jgltf-viewer/src/main/java/de/javagl/jgltf/viewer/ViewConfiguration.java
@@ -47,17 +47,17 @@ final class ViewConfiguration
     /**
      * The supplier for the viewport, as an array [x, y, width, height]
      */
-    private final Supplier<float[]> viewportSupplier;
+    private final Supplier<double[]> viewportSupplier;
     
     /**
      * The supplier for the view matrix
      */
-    private final Supplier<float[]> viewMatrixSupplier;
+    private final Supplier<double[]> viewMatrixSupplier;
     
     /**
      * The supplier for the projection matrix
      */
-    private final Supplier<float[]> projectionMatrixSupplier;
+    private final Supplier<double[]> projectionMatrixSupplier;
     
     /**
      * Creates a new view configuration
@@ -66,7 +66,7 @@ final class ViewConfiguration
      * as 4 float elements, [x, y, width, height]
      */
     ViewConfiguration(
-        Supplier<float[]> viewportSupplier)
+        Supplier<double[]> viewportSupplier)
     {
         this.viewportSupplier = Objects.requireNonNull(
             viewportSupplier, "The viewportSupplier may not be null");
@@ -116,9 +116,9 @@ final class ViewConfiguration
      * 
      * @return The view matrix supplier
      */
-    private Supplier<float[]> createViewMatrixSupplier()
+    private Supplier<double[]> createViewMatrixSupplier()
     {
-        float defaultViewMatrix[] = MathUtils.createIdentity4x4();
+        double defaultViewMatrix[] = MathUtils.createIdentity4x4();
         return () ->
         {
             if (renderedCamera == null)
@@ -150,9 +150,9 @@ final class ViewConfiguration
      *  
      * @return The projection matrix supplier
      */
-    private Supplier<float[]> createProjectionMatrixSupplier()
+    private Supplier<double[]> createProjectionMatrixSupplier()
     {
-        float defaultProjectionMatrix[] = MathUtils.createIdentity4x4();
+        double defaultProjectionMatrix[] = MathUtils.createIdentity4x4();
         return () ->
         {
             if (renderedCamera == null)
@@ -170,7 +170,7 @@ final class ViewConfiguration
      * 
      * @return The viewport
      */
-    public float[] getViewport()
+    public double[] getViewport()
     {
         return viewportSupplier.get();
     }
@@ -184,7 +184,7 @@ final class ViewConfiguration
      * 
      * @return The view matrix
      */
-    public float[] getViewMatrix()
+    public double[] getViewMatrix()
     {
         return viewMatrixSupplier.get();
     }
@@ -198,7 +198,7 @@ final class ViewConfiguration
      * 
      * @return The view matrix
      */
-    public float[] getProjectionMatrix()
+    public double[] getProjectionMatrix()
     {
         return projectionMatrixSupplier.get();
     }


### PR DESCRIPTION
When reading Google Earth’s building models with `de.javagl:jgltf-model:2.0.3`, I encountered floating-point precision errors in the .glb models. Specifically, the TRS (Translation, Rotation, Scale) and matrix transformation values were read using `float`, providing only 7 digits of precision. Since model nodes are translated with the distance of the Earth's diameter (6,378,000m), this loss (range of error = -1m ~ 1m) becomes problematic in games (like Minecraft), where even minor discrepancies (0.2m) of model alignments can result in noticeable rendering artifacts.
| Google Earth Web | Minecraft |
|-|-|
| ![image](https://github.com/user-attachments/assets/2ba5fb91-c53f-4670-87a2-7861b09123f9) | ![image](https://github.com/user-attachments/assets/c51f005c-1f94-412f-8d2a-658fa137d43f) |

This PR modifies only the TRS values, matrix values, and their relevant calculations (`MathUtils`, `BoundingBox`, ...) to use `double` instead of `float`. By increasing the precision from 7 to 15 digits (for example, the translation vector will change from `[3258869.8, -1158451.4, -4877243.5]` to `[3258869.7866948475, -1158451.3178201506, -4877243.302543961]`), large coordinate values are handled accurately, eliminating the floating-point errors observed during rendering.