### PR TITLE
Add quantization utilities

### DIFF
--- a/jgltf-model-builder/src/test/java/de/javagl/jgltf/model/creation/example/GltfModelCreationNormalizedAttributesExample.java
+++ b/jgltf-model-builder/src/test/java/de/javagl/jgltf/model/creation/example/GltfModelCreationNormalizedAttributesExample.java
@@ -7,16 +7,25 @@ import java.awt.RenderingHints;
 import java.awt.geom.RoundRectangle2D;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.nio.ShortBuffer;
 
 import de.javagl.jgltf.impl.v2.GlTF;
+import de.javagl.jgltf.model.GltfConstants;
 import de.javagl.jgltf.model.GltfModel;
+import de.javagl.jgltf.model.Quantization;
 import de.javagl.jgltf.model.SceneModel;
+import de.javagl.jgltf.model.creation.AccessorModels;
 import de.javagl.jgltf.model.creation.GltfModelBuilder;
 import de.javagl.jgltf.model.creation.MaterialModels;
-import de.javagl.jgltf.model.creation.MeshPrimitiveModels;
+import de.javagl.jgltf.model.creation.MeshPrimitiveBuilder;
 import de.javagl.jgltf.model.creation.SceneModels;
+import de.javagl.jgltf.model.impl.DefaultAccessorModel;
 import de.javagl.jgltf.model.impl.DefaultMeshPrimitiveModel;
 import de.javagl.jgltf.model.impl.DefaultPbrMaterialModel;
+import de.javagl.jgltf.model.io.Buffers;
 import de.javagl.jgltf.model.io.GltfWriter;
 import de.javagl.jgltf.model.io.v2.GltfAssetV2;
 import de.javagl.jgltf.model.io.v2.GltfAssetsV2;
@@ -25,7 +34,7 @@ import de.javagl.jgltf.model.io.v2.GltfAssetsV2;
  * A basic example for the glTF model creation.
  */
 @SuppressWarnings("javadoc")
-public class GltfModelCreationTextureExample
+public class GltfModelCreationNormalizedAttributesExample
 {
     public static void main(String[] args) throws Exception
     {
@@ -62,8 +71,27 @@ public class GltfModelCreationTextureExample
             0.0f, 0.0f,
             1.0f, 0.0f,
         };
-        DefaultMeshPrimitiveModel meshPrimitiveModel = 
-            MeshPrimitiveModels.create(indices, positions, normals, texCoords);
+        
+        // Create a mesh primitive, adding the indices, positions, and
+        // normals from the given array
+        MeshPrimitiveBuilder builder = MeshPrimitiveBuilder.create();
+        builder.setTriangles();
+        builder.setIntIndicesAsShort(IntBuffer.wrap(indices));
+        builder.addPositions3D(FloatBuffer.wrap(positions));
+        builder.addNormals3D(FloatBuffer.wrap(normals));
+        
+        // Quantize the texture coordinates into unsigned short values,
+        // create an accessor model, and assign it to the mesh primitive
+        FloatBuffer texCoordsBuffer = FloatBuffer.wrap(texCoords);
+        ShortBuffer texCoordsQuantized = 
+            Quantization.quantizeToUnsignedShortBuffer(texCoordsBuffer);
+        ByteBuffer texCoordsData = 
+            Buffers.createByteBufferFrom(texCoordsQuantized);
+        DefaultAccessorModel texCoordsAccessor = AccessorModels.create(
+            GltfConstants.GL_UNSIGNED_SHORT, "VEC2", true, texCoordsData);
+        builder.addAttribute("TEXCOORD_0", texCoordsAccessor);
+
+        DefaultMeshPrimitiveModel meshPrimitiveModel = builder.build();
         
         // Create a material from a buffered image
         BufferedImage bufferedImage = createTextureImage();

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/Quantization.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/Quantization.java
@@ -1,0 +1,455 @@
+/*
+ * www.javagl.de - JglTF
+ *
+ * Copyright 2015-2016 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jgltf.model;
+
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+import java.nio.ShortBuffer;
+
+import de.javagl.jgltf.model.io.Buffers;
+
+/**
+ * Utility methods for quantization.
+ */
+public class Quantization
+{
+    /**
+     * Returns the data from the given accessor model as a float buffer, tightly
+     * packed, applying dequantization as necessary.
+     * 
+     * If the component type of the given accessor model is
+     * <code>GL_FLOAT</code>, then the data will be returned directly.
+     * 
+     * If the component type is <code>GL_BYTE</code>,
+     * <code>GL_UNSIGNED_BYTE</code>, <code>GL_SHORT</code>, or
+     * <code>GL_UNSIGNED_SHORT</code>, then the data will be dequantized into
+     * float values.
+     * 
+     * Note: This does not check whether the accessor model is indeed normalized
+     * as of {@link AccessorModel#isNormalized()}.
+     *
+     * @param accessorModel The accessor model
+     * @return The buffer
+     * @throws IllegalArgumentException If the component type of the given
+     *         accessor model is neither float, nor signed/unsigned byte/short.
+     */
+    static FloatBuffer readAsFloatBuffer(AccessorModel accessorModel)
+    {
+        AccessorData accessorData = accessorModel.getAccessorData();
+        int componentType = accessorModel.getComponentType();
+        if (componentType == GltfConstants.GL_FLOAT)
+        {
+            ByteBuffer inputByteBuffer = accessorData.createByteBuffer();
+            return inputByteBuffer.asFloatBuffer();
+        }
+        if (componentType == GltfConstants.GL_BYTE)
+        {
+            ByteBuffer inputByteBuffer = accessorData.createByteBuffer();
+            return dequantizeByteBuffer(inputByteBuffer);
+        }
+        if (componentType == GltfConstants.GL_UNSIGNED_BYTE)
+        {
+            ByteBuffer inputByteBuffer = accessorData.createByteBuffer();
+            return dequantizeUnsignedByteBuffer(inputByteBuffer);
+        }
+        if (componentType == GltfConstants.GL_SHORT)
+        {
+            ByteBuffer inputByteBuffer = accessorData.createByteBuffer();
+            ShortBuffer shortBuffer = inputByteBuffer.asShortBuffer();
+            return dequantizeShortBuffer(shortBuffer);
+        }
+        if (componentType == GltfConstants.GL_UNSIGNED_SHORT)
+        {
+            ByteBuffer inputByteBuffer = accessorData.createByteBuffer();
+            ShortBuffer shortBuffer = inputByteBuffer.asShortBuffer();
+            return dequantizeUnsignedShortBuffer(shortBuffer);
+        }
+        throw new IllegalArgumentException(
+            "Component type " + GltfConstants.stringFor(componentType)
+                + " cannot be converted to float");
+    }
+
+    /**
+     * Dequantize the given buffer into a float buffer, treating each element of
+     * the input as a signed byte.
+     *
+     * @param byteBuffer The input buffer
+     * @return The result
+     */
+    public static FloatBuffer dequantizeByteBuffer(ByteBuffer byteBuffer)
+    {
+        FloatBuffer floatBuffer = FloatBuffer.allocate(byteBuffer.capacity());
+        dequantizeByteBuffer(byteBuffer, floatBuffer);
+        return floatBuffer;
+    }
+
+    /**
+     * Dequantize the given buffer into a float buffer, treating each element of
+     * the input as a signed byte.
+     *
+     * @param byteBuffer The input buffer
+     * @param floatBuffer The output buffer
+     */
+    private static void dequantizeByteBuffer(ByteBuffer byteBuffer,
+        FloatBuffer floatBuffer)
+    {
+        for (int i = 0; i < byteBuffer.capacity(); i++)
+        {
+            byte c = byteBuffer.get(i);
+            float f = dequantizeByte(c);
+            floatBuffer.put(i, f);
+        }
+    }
+
+    /**
+     * Dequantize the given buffer into a float buffer, treating each element of
+     * the input as an unsigned byte.
+     *
+     * @param byteBuffer The input buffer
+     * @return The result
+     */
+    public static FloatBuffer
+        dequantizeUnsignedByteBuffer(ByteBuffer byteBuffer)
+    {
+        FloatBuffer floatBuffer = FloatBuffer.allocate(byteBuffer.capacity());
+        dequantizeUnsignedByteBuffer(byteBuffer, floatBuffer);
+        return floatBuffer;
+    }
+
+    /**
+     * Dequantize the given buffer into a float buffer, treating each element of
+     * the input as an unsigned byte.
+     *
+     * @param byteBuffer The input buffer
+     * @param floatBuffer The output buffer
+     */
+    private static void dequantizeUnsignedByteBuffer(ByteBuffer byteBuffer,
+        FloatBuffer floatBuffer)
+    {
+        for (int i = 0; i < byteBuffer.capacity(); i++)
+        {
+            byte c = byteBuffer.get(i);
+            float f = dequantizeUnsignedByte(c);
+            floatBuffer.put(i, f);
+        }
+    }
+
+    /**
+     * Dequantize the given buffer into a float buffer, treating each element of
+     * the input as a signed short.
+     *
+     * @param shortBuffer The input buffer
+     * @return The result
+     */
+    public static FloatBuffer dequantizeShortBuffer(ShortBuffer shortBuffer)
+    {
+        FloatBuffer floatBuffer = FloatBuffer.allocate(shortBuffer.capacity());
+        dequantizeShortBuffer(shortBuffer, floatBuffer);
+        return floatBuffer;
+    }
+
+    /**
+     * Dequantize the given buffer into a float buffer, treating each element of
+     * the input as a signed short.
+     *
+     * @param shortBuffer The input buffer
+     * @param floatBuffer The output buffer
+     */
+    private static void dequantizeShortBuffer(ShortBuffer shortBuffer,
+        FloatBuffer floatBuffer)
+    {
+        for (int i = 0; i < shortBuffer.capacity(); i++)
+        {
+            short c = shortBuffer.get(i);
+            float f = dequantizeShort(c);
+            floatBuffer.put(i, f);
+        }
+    }
+
+    /**
+     * Dequantize the given buffer into a float buffer, treating each element of
+     * the input as an unsigned short.
+     *
+     * @param shortBuffer The input buffer
+     * @return The result
+     */
+    public static FloatBuffer
+        dequantizeUnsignedShortBuffer(ShortBuffer shortBuffer)
+    {
+        FloatBuffer floatBuffer = FloatBuffer.allocate(shortBuffer.capacity());
+        dequantizeUnsignedShortBuffer(shortBuffer, floatBuffer);
+        return floatBuffer;
+    }
+
+    /**
+     * Dequantize the given buffer into a float buffer, treating each element of
+     * the input as an unsigned short.
+     *
+     * @param shortBuffer The input buffer
+     * @param floatBuffer The output buffer
+     */
+    private static void dequantizeUnsignedShortBuffer(ShortBuffer shortBuffer,
+        FloatBuffer floatBuffer)
+    {
+        for (int i = 0; i < shortBuffer.capacity(); i++)
+        {
+            short c = shortBuffer.get(i);
+            float f = dequantizeUnsignedShort(c);
+            floatBuffer.put(i, f);
+        }
+    }
+
+    /**
+     * Dequantize the given signed byte into a floating point value
+     *
+     * @param c The input
+     * @return The result
+     */
+    private static float dequantizeByte(byte c)
+    {
+        float f = Math.max(c / 127.0f, -1.0f);
+        return f;
+    }
+
+    /**
+     * Dequantize the given unsigned byte into a floating point value
+     *
+     * @param c The input
+     * @return The result
+     */
+    private static float dequantizeUnsignedByte(byte c)
+    {
+        int i = Byte.toUnsignedInt(c);
+        float f = i / 255.0f;
+        return f;
+    }
+
+    /**
+     * Dequantize the given signed short into a floating point value
+     *
+     * @param c The input
+     * @return The result
+     */
+    private static float dequantizeShort(short c)
+    {
+        float f = Math.max(c / 32767.0f, -1.0f);
+        return f;
+    }
+
+    /**
+     *
+     * Dequantize the given unsigned byte into a floating point value
+     *
+     * @param c The input
+     * @return The result
+     */
+    private static float dequantizeUnsignedShort(short c)
+    {
+        int i = Short.toUnsignedInt(c);
+        float f = i / 65535.0f;
+        return f;
+    }
+
+    /**
+     * Quantize the given float buffer into a buffer with signed bytes
+     *
+     * @param floatBuffer The input buffer
+     * @return The result
+     */
+    public static ByteBuffer quantizeToByteBuffer(FloatBuffer floatBuffer)
+    {
+        ByteBuffer byteBuffer = Buffers.create(floatBuffer.capacity());
+        quantizeToByteBuffer(floatBuffer, byteBuffer);
+        return byteBuffer;
+    }
+
+    /**
+     * Quantize the given float buffer into a buffer with signed bytes
+     *
+     * @param floatBuffer The input buffer
+     * @param byteBuffer The output buffer
+     */
+    private static void quantizeToByteBuffer(FloatBuffer floatBuffer,
+        ByteBuffer byteBuffer)
+    {
+        for (int i = 0; i < floatBuffer.capacity(); i++)
+        {
+            float f = floatBuffer.get(i);
+            byte c = quantizeByte(f);
+            byteBuffer.put(i, c);
+        }
+    }
+
+    /**
+     * Quantize the given float buffer into a buffer with unsigned bytes
+     *
+     * @param floatBuffer The input buffer
+     * @return The result
+     */
+    public static ByteBuffer
+        quantizeToUnsignedByteBuffer(FloatBuffer floatBuffer)
+    {
+        ByteBuffer byteBuffer = Buffers.create(floatBuffer.capacity());
+        quantizeToUnsignedByteBuffer(floatBuffer, byteBuffer);
+        return byteBuffer;
+    }
+
+    /**
+     * Quantize the given float buffer into a buffer with unsigned bytes
+     *
+     * @param floatBuffer The input buffer
+     * @param byteBuffer The output buffer
+     */
+    private static void quantizeToUnsignedByteBuffer(FloatBuffer floatBuffer,
+        ByteBuffer byteBuffer)
+    {
+        for (int i = 0; i < floatBuffer.capacity(); i++)
+        {
+            float f = floatBuffer.get(i);
+            byte c = quantizeUnsignedByte(f);
+            byteBuffer.put(i, c);
+        }
+    }
+
+    /**
+     * Quantize the given float buffer into a buffer with signed shorts
+     *
+     * @param floatBuffer The input buffer
+     * @return The result
+     */
+    public static ShortBuffer quantizeToShortBuffer(FloatBuffer floatBuffer)
+    {
+        ShortBuffer shortBuffer = ShortBuffer.allocate(floatBuffer.capacity());
+        quantizeToShortBuffer(floatBuffer, shortBuffer);
+        return shortBuffer;
+    }
+
+    /**
+     * Quantize the given float buffer into a buffer with signed shorts
+     *
+     * @param floatBuffer The input buffer
+     * @param shortBuffer The output buffer
+     */
+    private static void quantizeToShortBuffer(FloatBuffer floatBuffer,
+        ShortBuffer shortBuffer)
+    {
+        for (int i = 0; i < floatBuffer.capacity(); i++)
+        {
+            float f = floatBuffer.get(i);
+            short c = quantizeShort(f);
+            shortBuffer.put(i, c);
+        }
+    }
+
+    /**
+     * Quantize the given float buffer into a buffer with unsigned shorts
+     *
+     * @param floatBuffer The input buffer
+     * @return The result
+     */
+    public static ShortBuffer
+        quantizeToUnsignedShortBuffer(FloatBuffer floatBuffer)
+    {
+        ShortBuffer shortBuffer = ShortBuffer.allocate(floatBuffer.capacity());
+        quantizeToUnsignedShortBuffer(floatBuffer, shortBuffer);
+        return shortBuffer;
+    }
+
+    /**
+     * Quantize the given float buffer into a buffer with unsigned shorts
+     *
+     * @param floatBuffer The input buffer
+     * @param shortBuffer The output buffer
+     */
+    private static void quantizeToUnsignedShortBuffer(FloatBuffer floatBuffer,
+        ShortBuffer shortBuffer)
+    {
+        for (int i = 0; i < floatBuffer.capacity(); i++)
+        {
+            float f = floatBuffer.get(i);
+            short c = quantizeUnsignedShort(f);
+            shortBuffer.put(i, c);
+        }
+    }
+
+    /**
+     * Quantize the given floating point value into a signed byte
+     *
+     * @param f The input
+     * @return The result
+     */
+    private static byte quantizeByte(float f)
+    {
+        byte c = (byte) Math.round(f * 127.0f);
+        return c;
+    }
+
+    /**
+     * Quantize the given floating point value into an unsigned byte
+     *
+     * @param f The input
+     * @return The result
+     */
+    private static byte quantizeUnsignedByte(float f)
+    {
+        byte c = (byte) Math.round(f * 255.0f);
+        return c;
+    }
+
+    /**
+     * Quantize the given floating point value into a signed short
+     *
+     * @param f The input
+     * @return The result
+     */
+    private static short quantizeShort(float f)
+    {
+        short c = (short) Math.round(f * 32767.0f);
+        return c;
+    }
+
+    /**
+     * Quantize the given floating point value into an unsigned short
+     *
+     * @param f The input
+     * @return The result
+     */
+    private static short quantizeUnsignedShort(float f)
+    {
+        short c = (short) Math.round(f * 65535.0f);
+        return c;
+    }
+
+    /**
+     * Private constructor to prevent instantiation
+     */
+    private Quantization()
+    {
+        // Private constructor to prevent instantiation
+    }
+
+}


### PR DESCRIPTION
Partially addresses https://github.com/javagl/JglTF/issues/74 

Until now, the only change here is that there is a `Quantization` class that offers some conversion functions. For example, to create a texture coordinate accessor with `GL_UNSIGNED_SHORT`/`normalized` values, the `quantizeToUnsignedShortBuffer` function can be used as follows:

```java
FloatBuffer texCoordsBuffer = ...;

boolean normalized = true;
ShortBuffer texCoordsQuantized = 
    Quantization.quantizeToUnsignedShortBuffer(texCoordsBuffer);

DefaultAccessorModel texCoordsAccessor = AccessorModels.create(
    GltfConstants.GL_UNSIGNED_SHORT, "VEC2", normalized, 
        Buffers.createByteBufferFrom(texCoordsQuantized));
```

This is still a bit clumsy. I'll consider adding another convenience layer for this. This could be in the `MeshPrimitiveBuilder`, which currently offers some functions like `addTexCoords02D`, and could offer another one that accepts a `boolean normalized` parameter, like
`builder.addTexCoords02D(texCoordsBuffer, true); // Add them normalized`

---

Also, the issue around https://github.com/javagl/JglTF/issues/60#issuecomment-1081860313 suggested that some convenience functions for dequantization could be added _directly_ in the `Accessor ... Data` classes. For example, the `AccessorShortData` class currently offers functions like
`short value = data.get(e, c);`

It could offer functions like
`float value = data.getDequantized(e, c);`

Some things to consider:

1. there are two different `get` functions - the `getDequantized` would have to be offered for both
2. there also are `set` functions. So one could expect their `setQuantized(... , float value)` counterparts
3. Right now, the `Accessor ... Data` classes do not even "know" whether they are dealing with quantized/normalized data or not. 

The last one is not a _strong_ point, but makes me hesitate. Right now, they just represent the accessor data, as it is. There probably are places where it could be convenient to have that (de)quantization functionality "built-in" there, but I'm not sure if these classes are indeed the right place. I think that having the options to
- create a `normalized` `AccessorModel` by quantizing a given `FloatBuffer` and
- create a `FloatBuffer` by reading the (byte/short) data from a `normalized` `AccessorModel`
 
could be a better granularity for this.



