### PR TITLE
Resolve Java buffer incompatibility

### DIFF
--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/AccessorByteData.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/AccessorByteData.java
@@ -31,6 +31,8 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.Locale;
 
+import de.javagl.jgltf.model.io.Buffers;
+
 /**
  * A class for accessing the data that is described by an accessor.
  * It allows accessing the byte buffer of the buffer view of the
@@ -291,7 +293,7 @@ public final class AccessorByteData
             byte component = get(i);
             result.put(component);
         }
-        result.position(0);
+        Buffers.position(result, 0);
         return result;
     }
     

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/AccessorFloatData.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/AccessorFloatData.java
@@ -31,6 +31,8 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.Locale;
 
+import de.javagl.jgltf.model.io.Buffers;
+
 /**
  * A class for accessing the data that is described by an accessor.
  * It allows accessing the byte buffer of the buffer view of the
@@ -197,7 +199,7 @@ public final class AccessorFloatData
             float component = get(i);
             result.putFloat(component);
         }
-        result.position(0);
+        Buffers.position(result, 0);
         return result;
     }
     

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/AccessorIntData.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/AccessorIntData.java
@@ -31,6 +31,8 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.Locale;
 
+import de.javagl.jgltf.model.io.Buffers;
+
 /**
  * A class for accessing the data that is described by an accessor.
  * It allows accessing the byte buffer of the buffer view of the
@@ -292,7 +294,7 @@ public final class AccessorIntData
             int component = get(i);
             result.putInt(component);
         }
-        result.position(0);
+        Buffers.position(result, 0);
         return result;
     }
     

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/AccessorShortData.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/AccessorShortData.java
@@ -31,6 +31,8 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.Locale;
 
+import de.javagl.jgltf.model.io.Buffers;
+
 /**
  * A class for accessing the data that is described by an accessor.
  * It allows accessing the byte buffer of the buffer view of the
@@ -293,7 +295,7 @@ public final class AccessorShortData
             short component = get(i);
             result.putShort(component);
         }
-        result.position(0);
+        Buffers.position(result, 0);
         return result;
     }
     

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/io/Buffers.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/io/Buffers.java
@@ -27,6 +27,7 @@
 package de.javagl.jgltf.model.io;
 
 import java.io.InputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
@@ -108,16 +109,16 @@ public class Buffers
                     "The new limit is " + newLimit + ", but the capacity is "
                     + byteBuffer.capacity());
             }
-            byteBuffer.limit(newLimit);
-            byteBuffer.position(position);
+            Buffers.limit(byteBuffer, newLimit);
+            Buffers.position(byteBuffer, position);
             ByteBuffer slice = byteBuffer.slice();
             slice.order(byteBuffer.order());
             return slice;
         }
         finally
         {
-            byteBuffer.limit(oldLimit);
-            byteBuffer.position(oldPosition);
+            Buffers.limit(byteBuffer, oldLimit);
+            Buffers.position(byteBuffer, oldPosition);
         }
     }
     
@@ -147,7 +148,7 @@ public class Buffers
         ByteBuffer byteBuffer = ByteBuffer.allocateDirect(length);
         byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
         byteBuffer.put(data, offset, length);
-        byteBuffer.position(0);
+        Buffers.position(byteBuffer, 0);
         return byteBuffer;
     }
     
@@ -207,7 +208,7 @@ public class Buffers
         {
             newByteBuffer.put(byteBuffer.slice());
         }
-        newByteBuffer.position(0);
+        Buffers.position(newByteBuffer, 0);
         return newByteBuffer;
     }
     
@@ -355,6 +356,93 @@ public class Buffers
         }
     }
     
+    //=========================================================================
+    // The following methods are intended for handling an incompatibility 
+    // between Java 8 and later Java versions: The return type of these
+    // methods on the 'Buffer' class has changed, which can lead to
+    // a NoSuchMethodError when calling these methods on the return
+    // value of another call. The best summary that I found for this is
+    // in https://issues.apache.org/jira/browse/MRESOLVER-85 
+    
+    /**
+     * Calls 'buffer.position(newPosition)'
+     * 
+     * @param buffer The buffer
+     * @param newPosition The new position
+     * @return The buffer
+     */
+    public static Buffer position(Buffer buffer, int newPosition)
+    {
+        return buffer.position(newPosition);
+    }
+    
+    /**
+     * Calls 'buffer.limit(newLimit)'
+     * 
+     * @param buffer The buffer
+     * @param newLimit The new limit
+     * @return The buffer
+     */
+    public static Buffer limit(Buffer buffer, int newLimit)
+    {
+        return buffer.limit(newLimit);
+    }
+    
+    /**
+     * Calls 'buffer.flip()'
+     * 
+     * @param buffer The buffer
+     * @return The buffer
+     */
+    public static Buffer flip(Buffer buffer)
+    {
+        return buffer.flip();
+    }
+    
+    /**
+     * Calls 'buffer.clear()'
+     * 
+     * @param buffer The buffer
+     * @return The buffer
+     */
+    public static Buffer clear(Buffer buffer)
+    {
+        return buffer.clear();
+    }
+    
+    /**
+     * Calls 'buffer.mark()'
+     * 
+     * @param buffer The buffer
+     * @return The buffer
+     */
+    public static Buffer mark(Buffer buffer)
+    {
+        return buffer.mark();
+    }
+
+    /**
+     * Calls 'buffer.reset()'
+     * 
+     * @param buffer The buffer
+     * @return The buffer
+     */
+    public static Buffer reset(Buffer buffer)
+    {
+        return buffer.reset();
+    }
+    
+    /**
+     * Calls 'buffer.rewind()'
+     * 
+     * @param buffer The buffer
+     * @return The buffer
+     */
+    public static Buffer rewind(Buffer buffer)
+    {
+        return buffer.rewind();
+    }
+
     /**
      * Private constructor to prevent instantiation
      */

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/io/v1/BinaryAssetCreatorV1.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/io/v1/BinaryAssetCreatorV1.java
@@ -155,7 +155,7 @@ final class BinaryAssetCreatorV1
                 return shader.getShaderData(); 
             },
             binaryGltfByteBuffer);
-        binaryGltfByteBuffer.position(0);
+        Buffers.position(binaryGltfByteBuffer, 0);
 
         // For all existing BufferViews, create new ones that are updated to 
         // refer to the new binary glTF buffer, with the appropriate offset

--- a/jgltf-viewer-lwjgl/src/main/java/de/javagl/jgltf/viewer/lwjgl/GlContextLwjgl.java
+++ b/jgltf-viewer-lwjgl/src/main/java/de/javagl/jgltf/viewer/lwjgl/GlContextLwjgl.java
@@ -106,6 +106,7 @@ import java.nio.charset.Charset;
 import java.util.logging.Logger;
 
 import de.javagl.jgltf.model.GltfConstants;
+import de.javagl.jgltf.model.io.Buffers;
 import de.javagl.jgltf.viewer.GlContext;
 
 /**
@@ -151,10 +152,10 @@ class GlContextLwjgl implements GlContext
                 .order(ByteOrder.nativeOrder())
                 .asIntBuffer();
         }
-        uniformIntBuffer.position(0);
-        uniformIntBuffer.limit(uniformIntBuffer.capacity());
+        Buffers.position(uniformIntBuffer, 0);
+        Buffers.limit(uniformIntBuffer, uniformIntBuffer.capacity());
         uniformIntBuffer.put(value);
-        uniformIntBuffer.flip();
+        Buffers.flip(uniformIntBuffer);
         return uniformIntBuffer;
     }
 
@@ -176,10 +177,10 @@ class GlContextLwjgl implements GlContext
                 .order(ByteOrder.nativeOrder())
                 .asFloatBuffer();
         }
-        uniformFloatBuffer.position(0);
-        uniformFloatBuffer.limit(uniformFloatBuffer.capacity());
+        Buffers.position(uniformFloatBuffer, 0);
+        Buffers.limit(uniformFloatBuffer, uniformFloatBuffer.capacity());
         uniformFloatBuffer.put(value);
-        uniformFloatBuffer.flip();
+        Buffers.flip(uniformFloatBuffer);
         return uniformFloatBuffer;
     }
 
@@ -465,7 +466,7 @@ class GlContextLwjgl implements GlContext
         int glBufferView = glGenBuffers();
         glBindBuffer(target, glBufferView);
         ByteBuffer data = bufferViewData.slice();
-        data.limit(byteLength);
+        Buffers.limit(data, byteLength);
         glBufferData(target, bufferViewData, GL_STATIC_DRAW);
         return glBufferView;
     }


### PR DESCRIPTION
I've been developing with Java for well over 25 years now, and had _never_ encounted something like this before: There has been a binary incompatibility between Java versions. 

A good summary of this issue can be found at https://issues.apache.org/jira/browse/MRESOLVER-85 : The return type of some methods of the `ByteBuffer` class has been changed between Java 8 and Java 9. These methods override the corresponding methods from the `Buffer` base class. In Java 8, they returned a `Buffer`. In Java 9, they introduced covariant return types, so that these methods in `ByteBuffer` now return a `ByteBuffer` instead of a `Buffer`. This could lead to a `NoSuchMethodError` when calling one of these methods. 

Identifying and fixing the problematic places in a large code base _can_ be a bit tricky. 

A common suggestion for resolving it is to explicitly cast the object that the method is called on to `Buffer`. So a call like
`byteBuffer.position(1);`
has to be changed to
`((Buffer)byteBuffer).position(1);`

Not only is this ugly, it is also difficult to apply this consistently and maintain it in the long run. So for the change here, I solved this pragmatically, and with help of the Eclipse 'Introduce Indirection' refactoring: I simply redirected **all** calls to the problematic methods to a utility method in the `Buffers` class. This accepts a `Buffer` as its parameter, which has the same effect as casting the respective instance to `Buffer`, meaning that the right method can be resolved.

(Maybe this indirection is not 'necessary' at some places where it is applied. But I'd rather apply the blanket redirection than figuring this out on a case-by-case basis)

I'll leave this PR open for a while (instead of merging it immediately), in the hope that someone provides feedback. But I'll very likely merge it into `master` soon, and into the `v3.0.0-dev` branch for the upcoming 3.0.0 release.

