### PR TITLE
Skip enum validation in implementation classes

### DIFF
--- a/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/Accessor.java
+++ b/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/Accessor.java
@@ -196,16 +196,11 @@ public class Accessor
      * 
      * @param componentType The componentType to set
      * @throws NullPointerException If the given value is <code>null</code>
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setComponentType(Integer componentType) {
         if (componentType == null) {
             throw new NullPointerException((("Invalid value for componentType: "+ componentType)+", may not be null"));
-        }
-        if (((((componentType!= 5120)&&(componentType!= 5121))&&(componentType!= 5122))&&(componentType!= 5123))&&(componentType!= 5126)) {
-            throw new IllegalArgumentException((("Invalid value for componentType: "+ componentType)+", valid: [5120, 5121, 5122, 5123, 5126]"));
         }
         this.componentType = componentType;
     }
@@ -259,16 +254,11 @@ public class Accessor
      * 
      * @param type The type to set
      * @throws NullPointerException If the given value is <code>null</code>
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setType(String type) {
         if (type == null) {
             throw new NullPointerException((("Invalid value for type: "+ type)+", may not be null"));
-        }
-        if (((((((!"SCALAR".equals(type))&&(!"VEC2".equals(type)))&&(!"VEC3".equals(type)))&&(!"VEC4".equals(type)))&&(!"MAT2".equals(type)))&&(!"MAT3".equals(type)))&&(!"MAT4".equals(type))) {
-            throw new IllegalArgumentException((("Invalid value for type: "+ type)+", valid: [SCALAR, VEC2, VEC3, VEC4, MAT2, MAT3, MAT4]"));
         }
         this.type = type;
     }

--- a/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/AnimationChannelTarget.java
+++ b/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/AnimationChannelTarget.java
@@ -62,16 +62,11 @@ public class AnimationChannelTarget
      * 
      * @param path The path to set
      * @throws NullPointerException If the given value is <code>null</code>
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setPath(String path) {
         if (path == null) {
             throw new NullPointerException((("Invalid value for path: "+ path)+", may not be null"));
-        }
-        if (((!"translation".equals(path))&&(!"rotation".equals(path)))&&(!"scale".equals(path))) {
-            throw new IllegalArgumentException((("Invalid value for path: "+ path)+", valid: [translation, rotation, scale]"));
         }
         this.path = path;
     }

--- a/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/AnimationSampler.java
+++ b/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/AnimationSampler.java
@@ -73,17 +73,12 @@ public class AnimationSampler
      * Valid values: [LINEAR] 
      * 
      * @param interpolation The interpolation to set
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setInterpolation(String interpolation) {
         if (interpolation == null) {
             this.interpolation = interpolation;
             return ;
-        }
-        if (!"LINEAR".equals(interpolation)) {
-            throw new IllegalArgumentException((("Invalid value for interpolation: "+ interpolation)+", valid: [LINEAR]"));
         }
         this.interpolation = interpolation;
     }

--- a/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/Buffer.java
+++ b/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/Buffer.java
@@ -114,17 +114,12 @@ public class Buffer
      * Valid values: [arraybuffer, text] 
      * 
      * @param type The type to set
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setType(String type) {
         if (type == null) {
             this.type = type;
             return ;
-        }
-        if ((!"arraybuffer".equals(type))&&(!"text".equals(type))) {
-            throw new IllegalArgumentException((("Invalid value for type: "+ type)+", valid: [arraybuffer, text]"));
         }
         this.type = type;
     }

--- a/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/BufferView.java
+++ b/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/BufferView.java
@@ -149,17 +149,12 @@ public class BufferView
      * Valid values: [34962, 34963] 
      * 
      * @param target The target to set
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setTarget(Integer target) {
         if (target == null) {
             this.target = target;
             return ;
-        }
-        if ((target!= 34962)&&(target!= 34963)) {
-            throw new IllegalArgumentException((("Invalid value for target: "+ target)+", valid: [34962, 34963]"));
         }
         this.target = target;
     }

--- a/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/Camera.java
+++ b/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/Camera.java
@@ -100,16 +100,11 @@ public class Camera
      * 
      * @param type The type to set
      * @throws NullPointerException If the given value is <code>null</code>
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setType(String type) {
         if (type == null) {
             throw new NullPointerException((("Invalid value for type: "+ type)+", may not be null"));
-        }
-        if ((!"perspective".equals(type))&&(!"orthographic".equals(type))) {
-            throw new IllegalArgumentException((("Invalid value for type: "+ type)+", valid: [perspective, orthographic]"));
         }
         this.type = type;
     }

--- a/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/MeshPrimitive.java
+++ b/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/MeshPrimitive.java
@@ -197,17 +197,12 @@ public class MeshPrimitive
      * Valid values: [0, 1, 2, 3, 4, 5, 6] 
      * 
      * @param mode The mode to set
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setMode(Integer mode) {
         if (mode == null) {
             this.mode = mode;
             return ;
-        }
-        if (((((((mode!= 0)&&(mode!= 1))&&(mode!= 2))&&(mode!= 3))&&(mode!= 4))&&(mode!= 5))&&(mode!= 6)) {
-            throw new IllegalArgumentException((("Invalid value for mode: "+ mode)+", valid: [0, 1, 2, 3, 4, 5, 6]"));
         }
         this.mode = mode;
     }

--- a/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/Sampler.java
+++ b/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/Sampler.java
@@ -55,17 +55,12 @@ public class Sampler
      * Valid values: [9728, 9729] 
      * 
      * @param magFilter The magFilter to set
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setMagFilter(Integer magFilter) {
         if (magFilter == null) {
             this.magFilter = magFilter;
             return ;
-        }
-        if ((magFilter!= 9728)&&(magFilter!= 9729)) {
-            throw new IllegalArgumentException((("Invalid value for magFilter: "+ magFilter)+", valid: [9728, 9729]"));
         }
         this.magFilter = magFilter;
     }
@@ -99,17 +94,12 @@ public class Sampler
      * Valid values: [9728, 9729, 9984, 9985, 9986, 9987] 
      * 
      * @param minFilter The minFilter to set
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setMinFilter(Integer minFilter) {
         if (minFilter == null) {
             this.minFilter = minFilter;
             return ;
-        }
-        if ((((((minFilter!= 9728)&&(minFilter!= 9729))&&(minFilter!= 9984))&&(minFilter!= 9985))&&(minFilter!= 9986))&&(minFilter!= 9987)) {
-            throw new IllegalArgumentException((("Invalid value for minFilter: "+ minFilter)+", valid: [9728, 9729, 9984, 9985, 9986, 9987]"));
         }
         this.minFilter = minFilter;
     }
@@ -143,17 +133,12 @@ public class Sampler
      * Valid values: [33071, 33648, 10497] 
      * 
      * @param wrapS The wrapS to set
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setWrapS(Integer wrapS) {
         if (wrapS == null) {
             this.wrapS = wrapS;
             return ;
-        }
-        if (((wrapS!= 33071)&&(wrapS!= 33648))&&(wrapS!= 10497)) {
-            throw new IllegalArgumentException((("Invalid value for wrapS: "+ wrapS)+", valid: [33071, 33648, 10497]"));
         }
         this.wrapS = wrapS;
     }
@@ -187,17 +172,12 @@ public class Sampler
      * Valid values: [33071, 33648, 10497] 
      * 
      * @param wrapT The wrapT to set
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setWrapT(Integer wrapT) {
         if (wrapT == null) {
             this.wrapT = wrapT;
             return ;
-        }
-        if (((wrapT!= 33071)&&(wrapT!= 33648))&&(wrapT!= 10497)) {
-            throw new IllegalArgumentException((("Invalid value for wrapT: "+ wrapT)+", valid: [33071, 33648, 10497]"));
         }
         this.wrapT = wrapT;
     }

--- a/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/Shader.java
+++ b/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/Shader.java
@@ -62,16 +62,11 @@ public class Shader
      * 
      * @param type The type to set
      * @throws NullPointerException If the given value is <code>null</code>
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setType(Integer type) {
         if (type == null) {
             throw new NullPointerException((("Invalid value for type: "+ type)+", may not be null"));
-        }
-        if ((type!= 35632)&&(type!= 35633)) {
-            throw new IllegalArgumentException((("Invalid value for type: "+ type)+", valid: [35632, 35633]"));
         }
         this.type = type;
     }

--- a/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/TechniqueParameters.java
+++ b/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/TechniqueParameters.java
@@ -123,16 +123,11 @@ public class TechniqueParameters
      * 
      * @param type The type to set
      * @throws NullPointerException If the given value is <code>null</code>
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setType(Integer type) {
         if (type == null) {
             throw new NullPointerException((("Invalid value for type: "+ type)+", may not be null"));
-        }
-        if (((((((((((((((((((((type!= 5120)&&(type!= 5121))&&(type!= 5122))&&(type!= 5123))&&(type!= 5124))&&(type!= 5125))&&(type!= 5126))&&(type!= 35664))&&(type!= 35665))&&(type!= 35666))&&(type!= 35667))&&(type!= 35668))&&(type!= 35669))&&(type!= 35670))&&(type!= 35671))&&(type!= 35672))&&(type!= 35673))&&(type!= 35674))&&(type!= 35675))&&(type!= 35676))&&(type!= 35678)) {
-            throw new IllegalArgumentException((("Invalid value for type: "+ type)+", valid: [5120, 5121, 5122, 5123, 5124, 5125, 5126, 35664, 35665, 35666, 35667, 35668, 35669, 35670, 35671, 35672, 35673, 35674, 35675, 35676, 35678]"));
         }
         this.type = type;
     }

--- a/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/Texture.java
+++ b/jgltf-impl-v1/src/main/java/de/javagl/jgltf/impl/v1/Texture.java
@@ -65,17 +65,12 @@ public class Texture
      * Valid values: [6406, 6407, 6408, 6409, 6410] 
      * 
      * @param format The format to set
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setFormat(Integer format) {
         if (format == null) {
             this.format = format;
             return ;
-        }
-        if (((((format!= 6406)&&(format!= 6407))&&(format!= 6408))&&(format!= 6409))&&(format!= 6410)) {
-            throw new IllegalArgumentException((("Invalid value for format: "+ format)+", valid: [6406, 6407, 6408, 6409, 6410]"));
         }
         this.format = format;
     }
@@ -109,17 +104,12 @@ public class Texture
      * Valid values: [6406, 6407, 6408, 6409, 6410] 
      * 
      * @param internalFormat The internalFormat to set
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setInternalFormat(Integer internalFormat) {
         if (internalFormat == null) {
             this.internalFormat = internalFormat;
             return ;
-        }
-        if (((((internalFormat!= 6406)&&(internalFormat!= 6407))&&(internalFormat!= 6408))&&(internalFormat!= 6409))&&(internalFormat!= 6410)) {
-            throw new IllegalArgumentException((("Invalid value for internalFormat: "+ internalFormat)+", valid: [6406, 6407, 6408, 6409, 6410]"));
         }
         this.internalFormat = internalFormat;
     }
@@ -201,17 +191,12 @@ public class Texture
      * Valid values: [3553] 
      * 
      * @param target The target to set
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setTarget(Integer target) {
         if (target == null) {
             this.target = target;
             return ;
-        }
-        if (target!= 3553) {
-            throw new IllegalArgumentException((("Invalid value for target: "+ target)+", valid: [3553]"));
         }
         this.target = target;
     }
@@ -245,17 +230,12 @@ public class Texture
      * Valid values: [5121, 33635, 32819, 32820] 
      * 
      * @param type The type to set
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setType(Integer type) {
         if (type == null) {
             this.type = type;
             return ;
-        }
-        if ((((type!= 5121)&&(type!= 33635))&&(type!= 32819))&&(type!= 32820)) {
-            throw new IllegalArgumentException((("Invalid value for type: "+ type)+", valid: [5121, 33635, 32819, 32820]"));
         }
         this.type = type;
     }

--- a/jgltf-impl-v2/src/main/java/de/javagl/jgltf/impl/v2/Accessor.java
+++ b/jgltf-impl-v2/src/main/java/de/javagl/jgltf/impl/v2/Accessor.java
@@ -160,16 +160,11 @@ public class Accessor
      * 
      * @param componentType The componentType to set
      * @throws NullPointerException If the given value is <code>null</code>
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setComponentType(Integer componentType) {
         if (componentType == null) {
             throw new NullPointerException((("Invalid value for componentType: "+ componentType)+", may not be null"));
-        }
-        if ((((((componentType!= 5120)&&(componentType!= 5121))&&(componentType!= 5122))&&(componentType!= 5123))&&(componentType!= 5125))&&(componentType!= 5126)) {
-            throw new IllegalArgumentException((("Invalid value for componentType: "+ componentType)+", valid: [5120, 5121, 5122, 5123, 5125, 5126]"));
         }
         this.componentType = componentType;
     }
@@ -262,16 +257,11 @@ public class Accessor
      * 
      * @param type The type to set
      * @throws NullPointerException If the given value is <code>null</code>
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setType(String type) {
         if (type == null) {
             throw new NullPointerException((("Invalid value for type: "+ type)+", may not be null"));
-        }
-        if (((((((!"SCALAR".equals(type))&&(!"VEC2".equals(type)))&&(!"VEC3".equals(type)))&&(!"VEC4".equals(type)))&&(!"MAT2".equals(type)))&&(!"MAT3".equals(type)))&&(!"MAT4".equals(type))) {
-            throw new IllegalArgumentException((("Invalid value for type: "+ type)+", valid: [SCALAR, VEC2, VEC3, VEC4, MAT2, MAT3, MAT4]"));
         }
         this.type = type;
     }

--- a/jgltf-impl-v2/src/main/java/de/javagl/jgltf/impl/v2/AccessorSparseIndices.java
+++ b/jgltf-impl-v2/src/main/java/de/javagl/jgltf/impl/v2/AccessorSparseIndices.java
@@ -127,16 +127,11 @@ public class AccessorSparseIndices
      * 
      * @param componentType The componentType to set
      * @throws NullPointerException If the given value is <code>null</code>
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setComponentType(Integer componentType) {
         if (componentType == null) {
             throw new NullPointerException((("Invalid value for componentType: "+ componentType)+", may not be null"));
-        }
-        if (((componentType!= 5121)&&(componentType!= 5123))&&(componentType!= 5125)) {
-            throw new IllegalArgumentException((("Invalid value for componentType: "+ componentType)+", valid: [5121, 5123, 5125]"));
         }
         this.componentType = componentType;
     }

--- a/jgltf-impl-v2/src/main/java/de/javagl/jgltf/impl/v2/AnimationChannelTarget.java
+++ b/jgltf-impl-v2/src/main/java/de/javagl/jgltf/impl/v2/AnimationChannelTarget.java
@@ -77,16 +77,11 @@ public class AnimationChannelTarget
      * 
      * @param path The path to set
      * @throws NullPointerException If the given value is <code>null</code>
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setPath(String path) {
         if (path == null) {
             throw new NullPointerException((("Invalid value for path: "+ path)+", may not be null"));
-        }
-        if ((((!"translation".equals(path))&&(!"rotation".equals(path)))&&(!"scale".equals(path)))&&(!"weights".equals(path))) {
-            throw new IllegalArgumentException((("Invalid value for path: "+ path)+", valid: [translation, rotation, scale, weights]"));
         }
         this.path = path;
     }

--- a/jgltf-impl-v2/src/main/java/de/javagl/jgltf/impl/v2/AnimationSampler.java
+++ b/jgltf-impl-v2/src/main/java/de/javagl/jgltf/impl/v2/AnimationSampler.java
@@ -70,17 +70,12 @@ public class AnimationSampler
      * Valid values: [LINEAR, STEP, CUBICSPLINE] 
      * 
      * @param interpolation The interpolation to set
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setInterpolation(String interpolation) {
         if (interpolation == null) {
             this.interpolation = interpolation;
             return ;
-        }
-        if (((!"LINEAR".equals(interpolation))&&(!"STEP".equals(interpolation)))&&(!"CUBICSPLINE".equals(interpolation))) {
-            throw new IllegalArgumentException((("Invalid value for interpolation: "+ interpolation)+", valid: [LINEAR, STEP, CUBICSPLINE]"));
         }
         this.interpolation = interpolation;
     }

--- a/jgltf-impl-v2/src/main/java/de/javagl/jgltf/impl/v2/BufferView.java
+++ b/jgltf-impl-v2/src/main/java/de/javagl/jgltf/impl/v2/BufferView.java
@@ -194,17 +194,12 @@ public class BufferView
      * Valid values: [34962, 34963] 
      * 
      * @param target The target to set
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setTarget(Integer target) {
         if (target == null) {
             this.target = target;
             return ;
-        }
-        if ((target!= 34962)&&(target!= 34963)) {
-            throw new IllegalArgumentException((("Invalid value for target: "+ target)+", valid: [34962, 34963]"));
         }
         this.target = target;
     }

--- a/jgltf-impl-v2/src/main/java/de/javagl/jgltf/impl/v2/Camera.java
+++ b/jgltf-impl-v2/src/main/java/de/javagl/jgltf/impl/v2/Camera.java
@@ -106,16 +106,11 @@ public class Camera
      * 
      * @param type The type to set
      * @throws NullPointerException If the given value is <code>null</code>
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setType(String type) {
         if (type == null) {
             throw new NullPointerException((("Invalid value for type: "+ type)+", may not be null"));
-        }
-        if ((!"perspective".equals(type))&&(!"orthographic".equals(type))) {
-            throw new IllegalArgumentException((("Invalid value for type: "+ type)+", valid: [perspective, orthographic]"));
         }
         this.type = type;
     }

--- a/jgltf-impl-v2/src/main/java/de/javagl/jgltf/impl/v2/Material.java
+++ b/jgltf-impl-v2/src/main/java/de/javagl/jgltf/impl/v2/Material.java
@@ -246,17 +246,12 @@ public class Material
      * Valid values: [OPAQUE, MASK, BLEND] 
      * 
      * @param alphaMode The alphaMode to set
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setAlphaMode(String alphaMode) {
         if (alphaMode == null) {
             this.alphaMode = alphaMode;
             return ;
-        }
-        if (((!"OPAQUE".equals(alphaMode))&&(!"MASK".equals(alphaMode)))&&(!"BLEND".equals(alphaMode))) {
-            throw new IllegalArgumentException((("Invalid value for alphaMode: "+ alphaMode)+", valid: [OPAQUE, MASK, BLEND]"));
         }
         this.alphaMode = alphaMode;
     }

--- a/jgltf-impl-v2/src/main/java/de/javagl/jgltf/impl/v2/MeshPrimitive.java
+++ b/jgltf-impl-v2/src/main/java/de/javagl/jgltf/impl/v2/MeshPrimitive.java
@@ -194,17 +194,12 @@ public class MeshPrimitive
      * Valid values: [0, 1, 2, 3, 4, 5, 6] 
      * 
      * @param mode The mode to set
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setMode(Integer mode) {
         if (mode == null) {
             this.mode = mode;
             return ;
-        }
-        if (((((((mode!= 0)&&(mode!= 1))&&(mode!= 2))&&(mode!= 3))&&(mode!= 4))&&(mode!= 5))&&(mode!= 6)) {
-            throw new IllegalArgumentException((("Invalid value for mode: "+ mode)+", valid: [0, 1, 2, 3, 4, 5, 6]"));
         }
         this.mode = mode;
     }

--- a/jgltf-impl-v2/src/main/java/de/javagl/jgltf/impl/v2/Sampler.java
+++ b/jgltf-impl-v2/src/main/java/de/javagl/jgltf/impl/v2/Sampler.java
@@ -52,17 +52,12 @@ public class Sampler
      * Valid values: [9728, 9729] 
      * 
      * @param magFilter The magFilter to set
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setMagFilter(Integer magFilter) {
         if (magFilter == null) {
             this.magFilter = magFilter;
             return ;
-        }
-        if ((magFilter!= 9728)&&(magFilter!= 9729)) {
-            throw new IllegalArgumentException((("Invalid value for magFilter: "+ magFilter)+", valid: [9728, 9729]"));
         }
         this.magFilter = magFilter;
     }
@@ -83,17 +78,12 @@ public class Sampler
      * Valid values: [9728, 9729, 9984, 9985, 9986, 9987] 
      * 
      * @param minFilter The minFilter to set
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setMinFilter(Integer minFilter) {
         if (minFilter == null) {
             this.minFilter = minFilter;
             return ;
-        }
-        if ((((((minFilter!= 9728)&&(minFilter!= 9729))&&(minFilter!= 9984))&&(minFilter!= 9985))&&(minFilter!= 9986))&&(minFilter!= 9987)) {
-            throw new IllegalArgumentException((("Invalid value for minFilter: "+ minFilter)+", valid: [9728, 9729, 9984, 9985, 9986, 9987]"));
         }
         this.minFilter = minFilter;
     }
@@ -115,17 +105,12 @@ public class Sampler
      * Valid values: [33071, 33648, 10497] 
      * 
      * @param wrapS The wrapS to set
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setWrapS(Integer wrapS) {
         if (wrapS == null) {
             this.wrapS = wrapS;
             return ;
-        }
-        if (((wrapS!= 33071)&&(wrapS!= 33648))&&(wrapS!= 10497)) {
-            throw new IllegalArgumentException((("Invalid value for wrapS: "+ wrapS)+", valid: [33071, 33648, 10497]"));
         }
         this.wrapS = wrapS;
     }
@@ -159,17 +144,12 @@ public class Sampler
      * Valid values: [33071, 33648, 10497] 
      * 
      * @param wrapT The wrapT to set
-     * @throws IllegalArgumentException If the given value does not meet
-     * the given constraints
      * 
      */
     public void setWrapT(Integer wrapT) {
         if (wrapT == null) {
             this.wrapT = wrapT;
             return ;
-        }
-        if (((wrapT!= 33071)&&(wrapT!= 33648))&&(wrapT!= 10497)) {
-            throw new IllegalArgumentException((("Invalid value for wrapT: "+ wrapT)+", valid: [33071, 33648, 10497]"));
         }
         this.wrapT = wrapT;
     }


### PR DESCRIPTION
Addresses the comment from https://github.com/javagl/JglTF/issues/131#issuecomment-4018926394 : 

Types that are considered to be "enum" types in the glTF schema are generally modeled using `anyOf`. For example, [the `componentType` of an `accessor`](https://github.com/KhronosGroup/glTF/blob/f966a3fbabeaed32f3f807750e35aaffc59bf4ca/specification/2.0/schema/accessor.schema.json#L22) explicitly lists the types and values (as `const`) that are valid according to the core specification:
```
            "anyOf": [
                {
                    "const": 5120,
                    "description": "BYTE",
                    "type": "integer"
                },
                {
                    "const": 5121,
                    "description": "UNSIGNED_BYTE",
                    "type": "integer"
                },
                ...
```
(An aside: The [glTF 1.0 specification still used the `enum` property for that](https://github.com/KhronosGroup/glTF/blob/f966a3fbabeaed32f3f807750e35aaffc59bf4ca/specification/1.0/schema/accessor.schema.json#L34))

But the catch is: In glTF 2.0, **all** these types contain a wildcard type in that `anyOf` list that just defines the "base type":
```
                {
                    "type": "integer"
                }
```
The goal of this is to allow extensions to define _additional_ valid values. 

The most prominent case of this was the `mimeType` property of `image`, which originally was constrained to `"image/jpeg", "image/png"`. This meant that any extension that defines a new MIME type could not be implemented, because the implementation classes checked for the exact valid values, and threw an `IllegalArgumentException` for unknown types. For the `mimeType`, this was addressed [quite a while ago](https://github.com/javagl/JglTF/commit/4024e39cc7b18add4b90caffcaae24956ecf117e#diff-dc0bbd04ebf541fdfdfa3ca925f2d20ed64de086457ae9a6cdb0ccdd1afed2db). But the same applies to **all** enum types: Extensions are free to define new, valid values. The `impl` classes are so low-level that they cannot sensibly be made aware of these new values. 

So I decided to remove the enum value validation in the low-level `impl` classes.

This will be part of the 3.0.0 release. 

(It _could_ go into 2.x as well, but given that 2.x does not have proper extension support, it may not be such a critical issue here)

Just for reference: The output was created with https://github.com/javagl/JsonModelGen/tree/09954cd908cf8836778b98708d9050de5152a6de 

