### PR TITLE
Accept inverse bind matrices being null

### DIFF
--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/SkinModel.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/SkinModel.java
@@ -76,7 +76,11 @@ public interface SkinModel extends NamedModelElement
      * The result will be written to the given array, as a 4x4 matrix in 
      * column major order. If the given array is <code>null</code> or does
      * not have a length of 16, then a new array with length 16 will be 
-     * created and returned. 
+     * created and returned.<br>
+     * <br>
+     * This method may only be called when this model actually has inverse 
+     * bind matrices, as indicated by {@link #getInverseBindMatrices()}
+     * returning a non-<code>null</code> value.  
      *  
      * @param index The index of the joint
      * @param result The result array

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/impl/DefaultSkinModel.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/impl/DefaultSkinModel.java
@@ -121,8 +121,7 @@ public final class DefaultSkinModel extends AbstractNamedModelElement
      */
     public void setInverseBindMatrices(AccessorModel inverseBindMatrices)
     {
-        this.inverseBindMatrices = Objects.requireNonNull(
-            inverseBindMatrices, "The inverseBindMatrices may not be null");
+        this.inverseBindMatrices = inverseBindMatrices;
     }
     
 

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfModelCreatorV2.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfModelCreatorV2.java
@@ -1074,9 +1074,12 @@ public class GltfModelCreatorV2
             }
             
             Integer inverseBindMatricesIndex = skin.getInverseBindMatrices();
-            AccessorModel inverseBindMatrices = 
-                gltfModel.getAccessorModel(inverseBindMatricesIndex);
-            skinModel.setInverseBindMatrices(inverseBindMatrices);
+            if (inverseBindMatricesIndex != null)
+            {
+                AccessorModel inverseBindMatrices = 
+                    gltfModel.getAccessorModel(inverseBindMatricesIndex);
+                skinModel.setInverseBindMatrices(inverseBindMatrices);
+            }
         }
     }
     


### PR DESCRIPTION
Fixes https://github.com/javagl/JglTF/issues/141 : 

- Removes the `null`-check in `DefaultSkinModel#setInverseBindMatrices` 
- Adds a `null` check in `GltfModelCreatorV2`
- Adds a clarifying comment in `SkinModel#getInverseBindMatrix`

This is going into the current `v3.0.0-dev` branch, for JglTF 3.0.0. 

The same fix was integrated into the current `master` state, via https://github.com/javagl/JglTF/pull/144

Note that this does _not_ (yet) add dedicated regression tests. More extensive tests for related operations will likely become part of the version 3.0.0 update.
