### PR TITLE
Drafts for an `AnimationBuilder`

### DIFF
--- a/jgltf-model-builder/src/main/java/de/javagl/jgltf/model/creation/AnimationBuilder.java
+++ b/jgltf-model-builder/src/main/java/de/javagl/jgltf/model/creation/AnimationBuilder.java
@@ -1,0 +1,1393 @@
+/*
+ * www.javagl.de - JglTF
+ *
+ * Copyright 2015-2017 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jgltf.model.creation;
+
+import java.nio.FloatBuffer;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Function;
+
+import de.javagl.jgltf.model.AccessorModel;
+import de.javagl.jgltf.model.AnimationModel;
+import de.javagl.jgltf.model.AnimationModel.Channel;
+import de.javagl.jgltf.model.AnimationModel.Interpolation;
+import de.javagl.jgltf.model.AnimationModel.Sampler;
+import de.javagl.jgltf.model.MathUtils;
+import de.javagl.jgltf.model.NodeModel;
+import de.javagl.jgltf.model.impl.DefaultAnimationModel;
+import de.javagl.jgltf.model.impl.DefaultAnimationModel.DefaultChannel;
+import de.javagl.jgltf.model.impl.DefaultAnimationModel.DefaultSampler;
+import de.javagl.jgltf.model.io.Buffers;
+
+/**
+ * A class for building {@link DefaultAnimationModel} instances.<br>
+ * <br>
+ * This class exposes a few static classes that will usually not directly be
+ * used by most clients. These classes are only intended for handling the
+ * different interpolation types (linear, step, and spline) for the different
+ * node properties (translation, rotation, scale) as transparently and easily as
+ * possible.
+ * 
+ * Usually the process for building an animation will be as follows:
+ * 
+ * <ul>
+ * <li>Create an animation builder instance with
+ * {@link AnimationBuilder#create()}</li>
+ * <li>Create a channel builder with
+ * {@link AnimationBuilder#beginChannelLinear(NodeModel)}.<br>
+ * Different flavors of this function exist, one for each interpolation type.
+ * Additionally, there is a generic form of that, which allows passing in the
+ * interpolation types manually, for example:<br>
+ * 
+ * <pre>
+ * <code>
+ *     cb = ab.beginChannel(nodeModel, 
+ *       TranslationInterpolation.LINEAR, 
+ *       RotationInterpolation.STEP, 
+ *       ScaleInterpolation.SPLINE);
+ *     </code>
+ * </pre>
+ * 
+ * </li>
+ * <li>Use the {@link ChannelBuilder#translations()},
+ * {@link ChannelBuilder#rotations()}, and {@link ChannelBuilder#scales()}
+ * handles to pass in key frames.</li>
+ * <li><b>Important:</b> Mark the end of the channel, by calling
+ * {@link ChannelBuilder#end()}</li>
+ * 
+ * </ul>
+ * 
+ * A complete example for building a linear translation animation is shown here:
+ * 
+ * <pre>
+ * <code>
+ * AnimationBuilder ab = AnimationBuilder.create();
+ * ChannelBuilder<LinearT, LinearR, LinearS> cb = ab.beginChannelLinear(nodeModel);
+ * 
+ * cb.translations().add(0.5, 0.0, 0.0, 0.0);
+ * cb.translations().add(1.5, 1.0, 0.0, 0.0);
+ * cb.translations().add(2.5, 2.0, 0.0, 0.0);
+ * cb.translations().add(4.5, 0.0, 0.0, 0.0);
+ * 
+ * cb.end();
+ * 
+ * DefaultAnimationModel animationModel = ab.build();
+ * </code>
+ * </pre>
+ */
+public class AnimationBuilder
+{
+    // TODO: There should be a warning when the animation is built while
+    // a channel has not been "end()"ed.
+    // TODO: All rotation handles should offer "axis-angle" functions
+    
+    /**
+     * A class containing constants for translation interpolation
+     *
+     * @param <T> The interpolation type
+     */
+    public static class TranslationInterpolation<T>
+    {
+        /**
+         * Linear translation interpolation
+         */
+        public static final TranslationInterpolation<LinearT> LINEAR =
+            new TranslationInterpolation<LinearT>(LinearT::new);
+
+        /**
+         * Step translation interpolation
+         */
+        public static final TranslationInterpolation<StepT> STEP =
+            new TranslationInterpolation<StepT>(StepT::new);
+
+        /**
+         * Spline translation interpolation
+         */
+        public static final TranslationInterpolation<SplineT> SPLINE =
+            new TranslationInterpolation<SplineT>(SplineT::new);
+
+        /**
+         * The factory
+         */
+        private final Function<NodeModel, T> factory;
+
+        /**
+         * Create the interpolation instance
+         * 
+         * @param nodeModel The node model
+         * @return The instance
+         */
+        T create(NodeModel nodeModel)
+        {
+            return factory.apply(nodeModel);
+        }
+
+        /**
+         * Default constructor
+         * 
+         * @param factory The factory
+         */
+        private TranslationInterpolation(Function<NodeModel, T> factory)
+        {
+            this.factory = factory;
+        }
+    }
+
+    /**
+     * A class containing constants for rotation interpolation
+     *
+     * @param <R> The interpolation type
+     */
+    public static class RotationInterpolation<R>
+    {
+        /**
+         * Linear rotation interpolation
+         */
+        public static final RotationInterpolation<LinearR> LINEAR =
+            new RotationInterpolation<LinearR>(LinearR::new);
+
+        /**
+         * Step rotation interpolation
+         */
+        public static final RotationInterpolation<StepR> STEP =
+            new RotationInterpolation<StepR>(StepR::new);
+
+        /**
+         * Spline rotation interpolation
+         */
+        public static final RotationInterpolation<SplineR> SPLINE =
+            new RotationInterpolation<SplineR>(SplineR::new);
+
+        /**
+         * The factory
+         */
+        private final Function<NodeModel, R> factory;
+
+        /**
+         * Create the interpolation instance
+         * 
+         * @param nodeModel The node model
+         * @return The instance
+         */
+        R create(NodeModel nodeModel)
+        {
+            return factory.apply(nodeModel);
+        }
+
+        /**
+         * Default constructor
+         * 
+         * @param factory The factory
+         */
+        private RotationInterpolation(Function<NodeModel, R> factory)
+        {
+            this.factory = factory;
+        }
+    }
+
+    /**
+     * A class containing constants for scale interpolation
+     *
+     * @param <S> The interpolation type
+     */
+    public static class ScaleInterpolation<S>
+    {
+        /**
+         * Linear scale interpolation
+         */
+        public static final ScaleInterpolation<LinearS> LINEAR =
+            new ScaleInterpolation<LinearS>(LinearS::new);
+
+        /**
+         * Step scale interpolation
+         */
+        public static final ScaleInterpolation<StepS> STEP =
+            new ScaleInterpolation<StepS>(StepS::new);
+
+        /**
+         * Spline scale interpolation
+         */
+        public static final ScaleInterpolation<SplineS> SPLINE =
+            new ScaleInterpolation<SplineS>(SplineS::new);
+
+        /**
+         * The factory
+         */
+        private final Function<NodeModel, S> factory;
+
+        /**
+         * Create the interpolation instance
+         * 
+         * @param nodeModel The node model
+         * @return The instance
+         */
+        S create(NodeModel nodeModel)
+        {
+            return factory.apply(nodeModel);
+        }
+
+        /**
+         * Default constructor
+         * 
+         * @param factory The factory
+         */
+        private ScaleInterpolation(Function<NodeModel, S> factory)
+        {
+            this.factory = factory;
+        }
+    }
+
+    /**
+     * Interface for interpolation channel component handles
+     */
+    private static interface Handle
+    {
+        /**
+         * Returns all times for the animation channel
+         * 
+         * @return The times
+         */
+        Set<Double> getTimes();
+
+        /**
+         * Creates the channel
+         * 
+         * @param timesAccessorModel The accessor model for the times
+         * @return The channel
+         */
+        DefaultChannel createChannel(AccessorModel timesAccessorModel);
+    }
+
+    /**
+     * A base class for linear and step animations
+     */
+    private static class SimpleHandle implements Handle
+    {
+        /**
+         * The node model for the animation channel
+         */
+        private final NodeModel nodeModel;
+
+        /**
+         * The interpolation (STEP or LINEAR)
+         */
+        private final Interpolation interpolation;
+
+        /**
+         * The number of components.
+         * 
+         * This is 3 for translation and scale, and 4 for rotations
+         */
+        private final int components;
+
+        /**
+         * The channel path, "translation", "rotation", or "scale"
+         */
+        private final String path;
+
+        /**
+         * The mapping from key frame times to values
+         */
+        private final Map<Double, double[]> map;
+
+        /**
+         * Creates a new instance
+         * 
+         * @param nodeModel The node model
+         * @param components The number of components
+         * @param interpolation The interpolation
+         * @param path The path
+         */
+        private SimpleHandle(NodeModel nodeModel, int components,
+            Interpolation interpolation, String path)
+        {
+            this.nodeModel = nodeModel;
+            this.components = components;
+            this.interpolation = interpolation;
+            this.path = path;
+            this.map = new TreeMap<Double, double[]>();
+        }
+
+        /**
+         * Add the given key frame
+         * 
+         * @param time The time
+         * @param values The values
+         */
+        protected final void addInternal(double time, double values[])
+        {
+            if (values.length != components)
+            {
+                throw new IllegalArgumentException(
+                    "The values must have a length of " + components
+                        + ", but have a length of " + values.length);
+            }
+            map.put(time, values);
+        }
+
+        @Override
+        public Set<Double> getTimes()
+        {
+            return map.keySet();
+        }
+
+        @Override
+        public DefaultChannel createChannel(AccessorModel timesAccessorModel)
+        {
+            FloatBuffer buffer = flatten1D(map.values(), components);
+            AccessorModel accessorModel;
+            if (components == 3)
+            {
+                accessorModel = AccessorModels.createFloat3D(buffer);
+            }
+            else
+            {
+                accessorModel = AccessorModels.createFloat4D(buffer);
+            }
+
+            Sampler sampler = new DefaultSampler(timesAccessorModel,
+                interpolation, accessorModel);
+
+            DefaultChannel channel =
+                new DefaultChannel(sampler, nodeModel, path);
+            return channel;
+        }
+
+    }
+
+    /**
+     * A base class for spline animations
+     */
+    private static class SplineHandle implements Handle
+    {
+        /**
+         * The node model for the animation channel
+         */
+        private final NodeModel nodeModel;
+
+        /**
+         * The number of components.
+         * 
+         * This is 3 for translation and scale, and 4 for rotations
+         */
+        private final int components;
+
+        /**
+         * The channel path, "translation", "rotation", or "scale"
+         */
+        private final String path;
+
+        /**
+         * The mapping from key frame times to values
+         */
+        private final Map<Double, double[][]> map;
+
+        /**
+         * Creates a new instance
+         * 
+         * @param nodeModel The node model
+         * @param components The number of components
+         * @param path The path
+         */
+        private SplineHandle(NodeModel nodeModel, int components, String path)
+        {
+            this.nodeModel = nodeModel;
+            this.components = components;
+            this.path = path;
+            this.map = new TreeMap<Double, double[][]>();
+        }
+
+        @Override
+        public Set<Double> getTimes()
+        {
+            return map.keySet();
+        }
+
+        /**
+         * Add the specified key frame
+         * 
+         * @param time The time
+         * @param values The values
+         */
+        protected final void addInternal(double time, double values[][])
+        {
+            if (values.length != 3)
+            {
+                throw new IllegalArgumentException(
+                    "The values must have a length of " + 3
+                        + ", but have a length of " + values.length);
+            }
+            for (double value[] : values)
+            {
+                if (value.length != components)
+                {
+                    throw new IllegalArgumentException(
+                        "Each of the values must have a length of " + components
+                            + ", but have a length of " + value.length);
+                }
+            }
+            map.put(time, values);
+        }
+
+        @Override
+        public DefaultChannel createChannel(AccessorModel timesAccessorModel)
+        {
+            FloatBuffer buffer = flatten2D(map.values(), 3 * components);
+
+            AccessorModel accessorModel;
+            if (components == 3)
+            {
+                accessorModel = AccessorModels.createFloat3D(buffer);
+            }
+            else
+            {
+                accessorModel = AccessorModels.createFloat4D(buffer);
+            }
+
+            Sampler sampler = new DefaultSampler(timesAccessorModel,
+                Interpolation.CUBICSPLINE, accessorModel);
+
+            DefaultChannel channel =
+                new DefaultChannel(sampler, nodeModel, path);
+            return channel;
+        }
+    }
+
+    /**
+     * A class for defining linear translation animations
+     */
+    public static class LinearT extends SimpleHandle
+    {
+        /**
+         * Default constructor
+         * 
+         * @param nodeModel The node model
+         */
+        private LinearT(NodeModel nodeModel)
+        {
+            super(nodeModel, 3, Interpolation.LINEAR, "translation");
+        }
+
+        /**
+         * Add the specified key frame
+         * 
+         * @param time The time
+         * @param x The x-component
+         * @param y The y-component
+         * @param z The z-component
+         * @return This instance
+         */
+        public LinearT add(double time, double x, double y, double z)
+        {
+            addInternal(time, new double[]
+            { x, y, z });
+            return this;
+        }
+
+        /**
+         * Add the specified key frame
+         * 
+         * @param time The time
+         * @param value The value
+         * @return This instance
+         */
+        public LinearT add(double time, double value[])
+        {
+            addInternal(time, value.clone());
+            return this;
+        }
+
+    }
+
+    /**
+     * A class for defining linear translation animations
+     */
+    public static class StepT extends SimpleHandle
+    {
+        /**
+         * Default constructor
+         * 
+         * @param nodeModel The node model
+         */
+        private StepT(NodeModel nodeModel)
+        {
+            super(nodeModel, 3, Interpolation.STEP, "translation");
+        }
+
+        /**
+         * Add the specified key frame
+         * 
+         * @param time The time
+         * @param x The x-component
+         * @param y The y-component
+         * @param z The z-component
+         * @return This instance
+         */
+        public StepT add(double time, double x, double y, double z)
+        {
+            addInternal(time, new double[]
+            { x, y, z });
+            return this;
+        }
+
+        /**
+         * Add the specified key frame
+         * 
+         * @param time The time
+         * @param value The value
+         * @return This instance
+         */
+        public StepT add(double time, double value[])
+        {
+            addInternal(time, value.clone());
+            return this;
+        }
+
+    }
+
+    /**
+     * A class for defining spline translation animations
+     */
+    public static class SplineT extends SplineHandle
+    {
+        /**
+         * Default constructor
+         * 
+         * @param nodeModel The node model
+         */
+        private SplineT(NodeModel nodeModel)
+        {
+            super(nodeModel, 3, "translation");
+        }
+
+        /**
+         * Add the specified key frame
+         * 
+         * @param time The time
+         * @param xIn The x-component of the in-tangent
+         * @param yIn The y-component of the in-tangent
+         * @param zIn The z-component of the in-tangent
+         * @param x The x-component
+         * @param y The y-component
+         * @param z The z-component
+         * @param xOut The x-component of the out-tangent
+         * @param yOut The y-component of the out-tangent
+         * @param zOut The z-component of the out-tangent
+         * @return This instance
+         */
+        public SplineT add(double time, double xIn, double yIn, double zIn,
+            double x, double y, double z, double xOut, double yOut, double zOut)
+        {
+            double v[][] = new double[3][3];
+            v[0][0] = xIn;
+            v[0][1] = yIn;
+            v[0][2] = zIn;
+
+            v[1][0] = x;
+            v[1][1] = y;
+            v[1][2] = z;
+
+            v[2][0] = xOut;
+            v[2][1] = yOut;
+            v[2][2] = zOut;
+            addInternal(time, v);
+            return this;
+        }
+
+        /**
+         * Add the specified key frame
+         * 
+         * @param time The time
+         * @param in The in-tangent
+         * @param v The key frame
+         * @param out The out-tangent
+         * @return This instance
+         */
+        public SplineT add(double time, double in[], double v[], double out[])
+        {
+            double vs[][] = new double[3][];
+            vs[0] = in.clone();
+            vs[1] = v.clone();
+            vs[2] = out.clone();
+            addInternal(time, vs);
+            return this;
+        }
+
+    }
+
+    /**
+     * A class for defining linear rotation animations
+     */
+    public static class LinearR extends SimpleHandle
+    {
+        /**
+         * Default constructor
+         * 
+         * @param nodeModel The node model
+         */
+        private LinearR(NodeModel nodeModel)
+        {
+            super(nodeModel, 4, Interpolation.LINEAR, "rotation");
+        }
+
+        /**
+         * Add the specified key frame
+         * 
+         * @param time The time
+         * @param x The x-component
+         * @param y The y-component
+         * @param z The z-component
+         * @param w The w-component
+         * @return This instance
+         */
+        public LinearR add(double time, double x, double y, double z, double w)
+        {
+            addInternal(time, new double[]
+            { x, y, z, w });
+            return this;
+        }
+
+        /**
+         * Add the specified key frame
+         * 
+         * @param time The time
+         * @param value The value
+         */
+        public void add(double time, double value[])
+        {
+            addInternal(time, value.clone());
+        }
+
+        /**
+         * Add the given rotation at the given time stamp
+         * 
+         * @param time The time stamp.
+         * 
+         * @param x The x-component of the rotation axis
+         * @param y The y-component of the rotation axis
+         * @param z The z-component of the rotation axis
+         * @param angleRad The rotation angle in radians
+         * @return This instance
+         */
+        public LinearR addAxisAngle(double time, double x, double y, double z,
+            double angleRad)
+        {
+            double q[] = new double[4];
+            MathUtils.axisAngleRadToQuaternion(x, y, z, angleRad, q);
+            addInternal(time, q);
+            return this;
+        }
+
+        /**
+         * Add the given rotation at the given time stamp
+         * 
+         * @param time The time stamp.
+         * @param axisAngle The axis and angle
+         * @return This instance
+         */
+        public LinearR addAxisAngle(double time, double axisAngle[])
+        {
+            return addAxisAngle(time, axisAngle[0], axisAngle[1], axisAngle[2],
+                axisAngle[3]);
+        }
+
+    }
+
+    /**
+     * A class for defining linear rotation animations
+     */
+    public static class StepR extends SimpleHandle
+    {
+        /**
+         * Default constructor
+         * 
+         * @param nodeModel The node model
+         */
+        private StepR(NodeModel nodeModel)
+        {
+            super(nodeModel, 4, Interpolation.STEP, "rotation");
+        }
+
+        /**
+         * Add the specified key frame
+         * 
+         * @param time The time
+         * @param x The x-component
+         * @param y The y-component
+         * @param z The z-component
+         * @param w The w-component
+         * @return This instance
+         */
+        public StepR add(double time, double x, double y, double z, double w)
+        {
+            addInternal(time, new double[]
+            { x, y, z, w });
+            return this;
+        }
+
+        /**
+         * Add the specified key frame
+         * 
+         * @param time The time
+         * @param value The value
+         * @return This instance
+         */
+        public StepR add(double time, double value[])
+        {
+            addInternal(time, value.clone());
+            return this;
+        }
+
+    }
+
+    /**
+     * A class for defining spline rotation animations
+     */
+    public static class SplineR extends SplineHandle
+    {
+        /**
+         * Default constructor
+         * 
+         * @param nodeModel The node model
+         */
+        private SplineR(NodeModel nodeModel)
+        {
+            super(nodeModel, 4, "rotation");
+        }
+
+        /**
+         * Add the specified key frame
+         * 
+         * @param time The time
+         * @param xIn The x-component of the in-tangent
+         * @param yIn The y-component of the in-tangent
+         * @param zIn The z-component of the in-tangent
+         * @param wIn The w-component of the in-tangent
+         * @param x The x-component
+         * @param y The y-component
+         * @param z The z-component
+         * @param w The w-component
+         * @param xOut The x-component of the out-tangent
+         * @param yOut The y-component of the out-tangent
+         * @param zOut The z-component of the out-tangent
+         * @param wOut The w-component of the out-tangent
+         * @return This instance
+         */
+        SplineR add(double time, double xIn, double yIn, double zIn, double wIn,
+            double x, double y, double z, double w, double xOut, double yOut,
+            double zOut, double wOut)
+        {
+            double v[][] = new double[3][4];
+            v[0][0] = xIn;
+            v[0][1] = yIn;
+            v[0][2] = zIn;
+            v[0][3] = wIn;
+
+            v[1][0] = x;
+            v[1][1] = y;
+            v[1][2] = z;
+            v[1][3] = w;
+
+            v[2][0] = xOut;
+            v[2][1] = yOut;
+            v[2][2] = zOut;
+            v[2][3] = wOut;
+            addInternal(time, v);
+            return this;
+        }
+
+        /**
+         * Add the specified key frame
+         * 
+         * @param time The time
+         * @param in The in-tangent
+         * @param v The key frame
+         * @param out The out-tangent
+         * @return This instance
+         */
+        public SplineR add(double time, double in[], double v[], double out[])
+        {
+            double vs[][] = new double[3][];
+            vs[0] = in.clone();
+            vs[1] = v.clone();
+            vs[2] = out.clone();
+            addInternal(time, vs);
+            return this;
+        }
+
+    }
+
+    /**
+     * A class for defining linear scale animations
+     */
+    public static class LinearS extends SimpleHandle
+    {
+        /**
+         * Default constructor
+         * 
+         * @param nodeModel The node model
+         */
+        private LinearS(NodeModel nodeModel)
+        {
+            super(nodeModel, 3, Interpolation.LINEAR, "scale");
+        }
+
+        /**
+         * Add the specified key frame
+         * 
+         * @param time The time
+         * @param x The x-component
+         * @param y The y-component
+         * @param z The z-component
+         * @return This instance
+         */
+        public LinearS add(double time, double x, double y, double z)
+        {
+            addInternal(time, new double[]
+            { x, y, z });
+            return this;
+        }
+
+        /**
+         * Add the specified key frame
+         * 
+         * @param time The time
+         * @param value The value
+         * @return This instance
+         */
+        public LinearS add(double time, double value[])
+        {
+            addInternal(time, value.clone());
+            return this;
+        }
+
+    }
+
+    /**
+     * A class for defining linear scale animations
+     */
+    public static class StepS extends SimpleHandle
+    {
+        /**
+         * Default constructor
+         * 
+         * @param nodeModel The node model
+         */
+        private StepS(NodeModel nodeModel)
+        {
+            super(nodeModel, 3, Interpolation.STEP, "scale");
+        }
+
+        /**
+         * Add the specified key frame
+         * 
+         * @param time The time
+         * @param x The x-component
+         * @param y The y-component
+         * @param z The z-component
+         * @return This instance
+         */
+        public StepS add(double time, double x, double y, double z)
+        {
+            addInternal(time, new double[]
+            { x, y, z });
+            return this;
+        }
+
+        /**
+         * Add the specified key frame
+         * 
+         * @param time The time
+         * @param value The value
+         * @return This instance
+         */
+        public StepS add(double time, double value[])
+        {
+            addInternal(time, value.clone());
+            return this;
+        }
+
+    }
+
+    /**
+     * A class for defining spline scale animations
+     */
+    public static class SplineS extends SplineHandle
+    {
+        /**
+         * Default constructor
+         * 
+         * @param nodeModel The node model
+         */
+        private SplineS(NodeModel nodeModel)
+        {
+            super(nodeModel, 3, "scale");
+        }
+
+        /**
+         * Add the specified key frame
+         * 
+         * @param time The time
+         * @param xIn The x-component of the in-tangent
+         * @param yIn The y-component of the in-tangent
+         * @param zIn The z-component of the in-tangent
+         * @param x The x-component
+         * @param y The y-component
+         * @param z The z-component
+         * @param xOut The x-component of the out-tangent
+         * @param yOut The y-component of the out-tangent
+         * @param zOut The z-component of the out-tangent
+         * @return This instance
+         */
+        public SplineS add(double time, double xIn, double yIn, double zIn,
+            double x, double y, double z, double xOut, double yOut, double zOut)
+        {
+            double v[][] = new double[3][3];
+            v[0][0] = xIn;
+            v[0][1] = yIn;
+            v[0][2] = zIn;
+
+            v[1][0] = x;
+            v[1][1] = y;
+            v[1][2] = z;
+
+            v[2][0] = xOut;
+            v[2][1] = yOut;
+            v[2][2] = zOut;
+            addInternal(time, v);
+            return this;
+        }
+
+        /**
+         * Add the specified key frame
+         * 
+         * @param time The time
+         * @param in The in-tangent
+         * @param v The key frame
+         * @param out The out-tangent
+         * @return This instance
+         */
+        public SplineS add(double time, double in[], double v[], double out[])
+        {
+            double vs[][] = new double[3][];
+            vs[0] = in.clone();
+            vs[1] = v.clone();
+            vs[2] = out.clone();
+            addInternal(time, vs);
+            return this;
+        }
+
+    }
+
+    /**
+     * A class for building animation channels
+     * 
+     * @param <T> The translation interpolation type
+     * @param <R> The rotation interpolation type
+     * @param <S> The scale interpolation type
+     */
+    public static class ChannelBuilder<T extends Handle, R extends Handle, S extends Handle>
+    {
+        /**
+         * The owner of this instance
+         */
+        private final AnimationBuilder owner;
+
+        /**
+         * The animation model that is built in the owner
+         */
+        private final DefaultAnimationModel animationModel;
+
+        /**
+         * The translation animation handler
+         */
+        private final T translations;
+
+        /**
+         * The rotation animation handler
+         */
+        private final R rotations;
+
+        /**
+         * The scale animation handler
+         */
+        private final S scales;
+
+        /**
+         * A lookup from key frame times to accessor models
+         */
+        private final Map<Set<Double>, AccessorModel> timesAccessorModels;
+
+        /**
+         * Creates a new instance
+         * 
+         * @param owner The owner
+         * @param animationModel The animation model
+         * @param translations The translation handle
+         * @param rotations The rotation handle
+         * @param scales The scale handle
+         */
+        ChannelBuilder(AnimationBuilder owner,
+            DefaultAnimationModel animationModel, T translations, R rotations,
+            S scales)
+        {
+            this.owner = owner;
+            this.animationModel = animationModel;
+            this.translations = translations;
+            this.rotations = rotations;
+            this.scales = scales;
+            this.timesAccessorModels =
+                new LinkedHashMap<Set<Double>, AccessorModel>();
+        }
+
+        /**
+         * Returns the handle for adding translation key frames
+         * 
+         * @return The handle
+         */
+        public T translations()
+        {
+            return translations;
+        }
+
+        /**
+         * Returns the handle for adding rotation key frames
+         * 
+         * @return The handle
+         */
+        public R rotations()
+        {
+            return rotations;
+        }
+
+        /**
+         * Returns the handle for adding scale key frames
+         * 
+         * @return The handle
+         */
+        public S scales()
+        {
+            return scales;
+        }
+
+        /**
+         * Obtain an accessor model for the given key frame times.
+         * 
+         * This will re-use existing accessor models that already represent the
+         * same key frame times
+         * 
+         * @param times The times
+         * @return The accessor model
+         */
+        private AccessorModel fetchTimesAccessorModel(Set<Double> times)
+        {
+            AccessorModel accessorModel = timesAccessorModels.get(times);
+            if (accessorModel != null)
+            {
+                return accessorModel;
+            }
+            FloatBuffer timesBuffer = floats(times);
+            accessorModel = AccessorModels.createFloatScalar(timesBuffer);
+            timesAccessorModels.put(times, accessorModel);
+            return accessorModel;
+        }
+
+        /**
+         * End building the animation channel
+         * 
+         * @return The animation builder
+         * @throws IllegalStateException If no key frames have been added after
+         *         this instance was created, or this instance contains key
+         *         frames for an animation channel that was already created
+         */
+        public AnimationBuilder end()
+        {
+            boolean created = false;
+
+            Set<Double> translationTimes = translations.getTimes();
+            if (!translationTimes.isEmpty())
+            {
+                AccessorModel timesAccessorModel =
+                    fetchTimesAccessorModel(translationTimes);
+                DefaultChannel translationChannel =
+                    translations.createChannel(timesAccessorModel);
+                ensureChannelPathIsNew(animationModel, "translation");
+                animationModel.addChannel(translationChannel);
+                created = true;
+            }
+
+            Set<Double> rotationTimes = rotations.getTimes();
+            if (!rotationTimes.isEmpty())
+            {
+                AccessorModel timesAccessorModel =
+                    fetchTimesAccessorModel(rotationTimes);
+                DefaultChannel rotationChannel =
+                    rotations.createChannel(timesAccessorModel);
+                ensureChannelPathIsNew(animationModel, "rotation");
+                animationModel.addChannel(rotationChannel);
+                created = true;
+            }
+
+            Set<Double> scaleTimes = scales.getTimes();
+            if (!scaleTimes.isEmpty())
+            {
+                AccessorModel timesAccessorModel =
+                    fetchTimesAccessorModel(scaleTimes);
+                DefaultChannel scaleChannel =
+                    scales.createChannel(timesAccessorModel);
+                ensureChannelPathIsNew(animationModel, "scale");
+                animationModel.addChannel(scaleChannel);
+                created = true;
+            }
+
+            if (!created)
+            {
+                throw new IllegalStateException(
+                    "No key frames have been added to the current channel.");
+            }
+            return owner;
+        }
+    }
+
+    /**
+     * Ensure that the given animation model does not contain a channel with the
+     * given path name, and throw an exception of this is not the case.
+     * 
+     * @param animationModel The animation model
+     * @param path The path
+     * @throws IllegalStateException If the path already exists
+     */
+    private static void ensureChannelPathIsNew(AnimationModel animationModel,
+        String path)
+    {
+        List<Channel> channels = animationModel.getChannels();
+        for (Channel channel : channels)
+        {
+            if (channel.getPath().equals(path))
+            {
+                throw new IllegalStateException(
+                    "The animation already has a '" + path + "' channel.");
+            }
+        }
+    }
+
+    /**
+     * Creates a new instance
+     * 
+     * @return The {@link AnimationBuilder}
+     */
+    public static AnimationBuilder create()
+    {
+        return new AnimationBuilder();
+    }
+
+    /**
+     * The animation model that is currently being built
+     */
+    private DefaultAnimationModel animationModel;
+
+    /**
+     * Private constructor to be called from {@link #create()}.
+     */
+    private AnimationBuilder()
+    {
+        this.animationModel = new DefaultAnimationModel();
+    }
+
+    /**
+     * Begin a new channel.
+     * 
+     * This will use LINEAR interpolation for translation, rotation, and scale
+     * 
+     * @param nodeModel The node model that should be affected
+     * @return The channel builder
+     */
+    public ChannelBuilder<LinearT, LinearR, LinearS>
+        beginChannelLinear(NodeModel nodeModel)
+    {
+        return beginChannel(nodeModel, TranslationInterpolation.LINEAR,
+            RotationInterpolation.LINEAR, ScaleInterpolation.LINEAR);
+    }
+
+    /**
+     * Begin a new channel.
+     * 
+     * This will use STEP interpolation for translation, rotation, and scale
+     * 
+     * @param nodeModel The node model that should be affected
+     * @return The channel builder
+     */
+    public ChannelBuilder<StepT, StepR, StepS>
+        beginChannelStep(NodeModel nodeModel)
+    {
+        return beginChannel(nodeModel, TranslationInterpolation.STEP,
+            RotationInterpolation.STEP, ScaleInterpolation.STEP);
+    }
+
+    /**
+     * Begin a new channel.
+     * 
+     * This will use SPLINE interpolation for translation, rotation, and scale
+     * 
+     * @param nodeModel The node model that should be affected
+     * @return The channel builder
+     */
+    public ChannelBuilder<SplineT, SplineR, SplineS>
+        beginChannelSpline(NodeModel nodeModel)
+    {
+        return beginChannel(nodeModel, TranslationInterpolation.SPLINE,
+            RotationInterpolation.SPLINE, ScaleInterpolation.SPLINE);
+    }
+
+    /**
+     * Begins a new channel with the given interpolation types
+     * 
+     * @param <T> The translation interpolation type
+     * @param <R> The rotation interpolation type
+     * @param <S> The scale interpolation type
+     * 
+     * @param nodeModel The node model
+     * @param translationInterpolation The translation interpolation
+     * @param rotationInterpolation The rotation interpolation
+     * @param scaleInterpolation The scale interpolation
+     * @return The channel builder
+     */
+    public <T extends Handle, R extends Handle, S extends Handle>
+        ChannelBuilder<T, R, S> beginChannel(NodeModel nodeModel,
+            TranslationInterpolation<T> translationInterpolation,
+            RotationInterpolation<R> rotationInterpolation,
+            ScaleInterpolation<S> scaleInterpolation)
+    {
+        Objects.requireNonNull(nodeModel, "The nodeModel may not be null");
+        Objects.requireNonNull(translationInterpolation,
+            "The translationInterpolation may not be null");
+        Objects.requireNonNull(rotationInterpolation,
+            "The rotationInterpolation may not be null");
+        Objects.requireNonNull(scaleInterpolation,
+            "The scaleInterpolation may not be null");
+
+        T translations = translationInterpolation.create(nodeModel);
+        R rotations = rotationInterpolation.create(nodeModel);
+        S scales = scaleInterpolation.create(nodeModel);
+        return new ChannelBuilder<T, R, S>(this, animationModel, translations,
+            rotations, scales);
+    }
+
+    /**
+     * Build the {@link DefaultAnimationModel} with the current state
+     * 
+     * @return The {@link DefaultAnimationModel}
+     */
+    public DefaultAnimationModel build()
+    {
+        DefaultAnimationModel result = animationModel;
+        if (animationModel.getChannels().isEmpty())
+        {
+            throw new IllegalStateException("No channels have been created. "
+                + "Use 'animationBuilder.beginChannel(...)' to create a "
+                + "channel builder, and 'channelBuilder.end()' to "
+                + "end the channel");
+        }
+        animationModel = new DefaultAnimationModel();
+        return result;
+    }
+
+    /**
+     * Convert the given collection into a float buffer.
+     * 
+     * The given list may not contain <code>null</code> elements.
+     * 
+     * @param collection The collection
+     * @return The float buffer
+     */
+    private static FloatBuffer floats(Collection<? extends Number> collection)
+    {
+        FloatBuffer buffer = FloatBuffer.allocate(collection.size());
+        int index = 0;
+        for (Number n : collection)
+        {
+            buffer.put(index, n.floatValue());
+            index++;
+        }
+        return buffer;
+    }
+
+    /**
+     * Flatten the given collection of arrays into a float buffer.
+     * 
+     * @param values The values
+     * @param valueLength The length of each value
+     * @return The buffer
+     */
+    private static FloatBuffer flatten1D(Collection<double[]> values,
+        int valueLength)
+    {
+        int totalSize = values.size() * valueLength;
+        FloatBuffer buffer = FloatBuffer.allocate(totalSize);
+        for (double v[] : values)
+        {
+            for (int i = 0; i < v.length; i++)
+            {
+                buffer.put((float) v[i]);
+            }
+        }
+        Buffers.position(buffer, 0);
+        return buffer;
+    }
+
+    /**
+     * Flatten the given collection of arrays into a float buffer.
+     * 
+     * @param values The values
+     * @param valueLength The length of each value
+     * @return The buffer
+     */
+    private static FloatBuffer flatten2D(Collection<double[][]> values,
+        int valueLength)
+    {
+        int totalSize = values.size() * valueLength;
+        FloatBuffer buffer = FloatBuffer.allocate(totalSize);
+        for (double v[][] : values)
+        {
+            for (int i = 0; i < v.length; i++)
+            {
+                for (int j = 0; j < v[i].length; j++)
+                {
+                    buffer.put((float) v[i][j]);
+                }
+            }
+        }
+        Buffers.position(buffer, 0);
+        return buffer;
+    }
+
+}

--- a/jgltf-model-builder/src/main/java/de/javagl/jgltf/model/creation/NodeModels.java
+++ b/jgltf-model-builder/src/main/java/de/javagl/jgltf/model/creation/NodeModels.java
@@ -1,0 +1,76 @@
+/*
+ * www.javagl.de - JglTF
+ *
+ * Copyright 2015-2017 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jgltf.model.creation;
+
+import de.javagl.jgltf.model.MeshModel;
+import de.javagl.jgltf.model.MeshPrimitiveModel;
+import de.javagl.jgltf.model.NodeModel;
+import de.javagl.jgltf.model.impl.DefaultMeshModel;
+import de.javagl.jgltf.model.impl.DefaultNodeModel;
+
+/**
+ * Methods related to {@link NodeModel} objects
+ */
+public class NodeModels
+{
+    /**
+     * Convenience function to create a {@link NodeModel} with a single mesh
+     * with the given primitive.
+     * 
+     * @param meshPrimitiveModel The {@link MeshPrimitiveModel}
+     * @return The {@link NodeModel}
+     */
+    public static DefaultNodeModel
+        createFromMeshPrimitive(MeshPrimitiveModel meshPrimitiveModel)
+    {
+        DefaultMeshModel meshModel = new DefaultMeshModel();
+        meshModel.addMeshPrimitiveModel(meshPrimitiveModel);
+        return createFromMesh(meshModel);
+    }
+
+    /**
+     * Convenience function to create a {@link NodeModel} with a single mesh.
+     * 
+     * @param meshModel The {@link MeshModel}
+     * @return The {@link NodeModel}
+     */
+    public static DefaultNodeModel createFromMesh(MeshModel meshModel)
+    {
+        DefaultNodeModel nodeModel = new DefaultNodeModel();
+        nodeModel.addMeshModel(meshModel);
+        return nodeModel;
+    }
+
+    /**
+     * Private constructor to prevent instantiation
+     */
+    private NodeModels()
+    {
+        // Private constructor to prevent instantiation
+    }
+
+}

--- a/jgltf-model-builder/src/test/java/de/javagl/jgltf/model/creation/example/GltfModelCreationAnimationExample.java
+++ b/jgltf-model-builder/src/test/java/de/javagl/jgltf/model/creation/example/GltfModelCreationAnimationExample.java
@@ -1,0 +1,141 @@
+package de.javagl.jgltf.model.creation.example;
+
+import java.io.File;
+
+import de.javagl.jgltf.model.GltfModel;
+import de.javagl.jgltf.model.NodeModel;
+import de.javagl.jgltf.model.PbrMaterialModel;
+import de.javagl.jgltf.model.SceneModel;
+import de.javagl.jgltf.model.creation.AnimationBuilder;
+import de.javagl.jgltf.model.creation.AnimationBuilder.ChannelBuilder;
+import de.javagl.jgltf.model.creation.AnimationBuilder.LinearR;
+import de.javagl.jgltf.model.creation.AnimationBuilder.RotationInterpolation;
+import de.javagl.jgltf.model.creation.AnimationBuilder.ScaleInterpolation;
+import de.javagl.jgltf.model.creation.AnimationBuilder.SplineS;
+import de.javagl.jgltf.model.creation.AnimationBuilder.StepT;
+import de.javagl.jgltf.model.creation.AnimationBuilder.TranslationInterpolation;
+import de.javagl.jgltf.model.creation.GltfModelBuilder;
+import de.javagl.jgltf.model.creation.MaterialModels;
+import de.javagl.jgltf.model.creation.MeshPrimitiveModels;
+import de.javagl.jgltf.model.creation.NodeModels;
+import de.javagl.jgltf.model.creation.SceneModels;
+import de.javagl.jgltf.model.impl.DefaultAnimationModel;
+import de.javagl.jgltf.model.impl.DefaultGltfModel;
+import de.javagl.jgltf.model.impl.DefaultMeshPrimitiveModel;
+import de.javagl.jgltf.model.io.GltfModelWriter;
+
+/**
+ * An example for creating animations.<br>
+ * <br>
+ */
+@SuppressWarnings("javadoc")
+public class GltfModelCreationAnimationExample
+{
+    public static void main(String[] args) throws Exception
+    {
+        GltfModel gltfModel = createGltfModel();
+        GltfModelWriter w = new GltfModelWriter();
+        w.writeEmbedded(gltfModel, new File("./data/animation.gltf"));
+    }
+
+    private static GltfModel createGltfModel()
+    {
+        DefaultMeshPrimitiveModel meshPrimitiveModel = createUnitSquare();
+
+        NodeModel nodeModel =
+            NodeModels.createFromMeshPrimitive(meshPrimitiveModel);
+
+        AnimationBuilder ab = AnimationBuilder.create();
+        ChannelBuilder<StepT, LinearR, SplineS> c0 =
+            ab.beginChannel(nodeModel, TranslationInterpolation.STEP,
+                RotationInterpolation.LINEAR, ScaleInterpolation.SPLINE);
+
+        // Define the 'scales' animation. This is using SPLINE interpolation,
+        // meaning that each time stamp is associated with the in-tangent,
+        // key frame, and out-tangent. Here, the in- and out-tangents are
+        // very large, to emphasize the effect of the SPLINE interpolation,
+        // causing the scaling to "overshoot" and "undershoot" the scaling
+        // of 3.0 and 1.0, respectively
+        // @formatter:off
+        c0.scales().add(0.5, 
+             0.0,  0.0,  0.0, 
+             1.0,  1.0,  1.0, 
+             5.0,  5.0,  5.0);
+        c0.scales().add(1.5, 
+            -5.0, -5.0, -5.0, 
+             3.0,  3.0,  3.0, 
+             0.0,  0.0,  0.0);
+        c0.scales().add(2.5, 
+             0.0,  0.0,  0.0, 
+             3.0,  3.0,  3.0, 
+            -5.0, -5.0, -5.0);
+        c0.scales().add(3.5, 
+             5.0,  5.0,  5.0, 
+             1.0,  1.0,  1.0,
+             0.0,  0.0 , 0.0);
+        // @formatter:off
+
+        // Add a rotation around (0,0,1), with LINEAR interpolation, 
+        // using the "axis-angle" convenience function
+        c0.rotations().addAxisAngle(5.0, 0.0, 0.0, 1.0, 0.0);
+        c0.rotations().addAxisAngle(5.5, 0.0, 0.0, 1.0, Math.toRadians(90.0));
+        c0.rotations().addAxisAngle(6.0, 0.0, 0.0, 1.0, Math.toRadians(90.0));
+        c0.rotations().addAxisAngle(6.5, 0.0, 0.0, 1.0, 0.0);
+        
+        // Add a translation, using STEP interpolation
+        c0.translations().add(7.0, 0.0, 0.0, 0.0);
+        c0.translations().add(7.5, 1.0, 0.0, 0.0);
+        c0.translations().add(8.0, 1.0, 1.0, 0.0);
+        c0.translations().add(8.5, 0.0, 1.0, 0.0);
+        c0.translations().add(9.0, 0.0, 0.0, 0.0);
+
+        c0.end();
+        
+        // Build the animation
+        DefaultAnimationModel animationModel = ab.build();
+        
+        // Create a scene that only contains the given node
+        SceneModel sceneModel =  SceneModels.createFromNode(nodeModel);
+        
+        // Pass the scene to the model builder. It will take care
+        // of the other model elements that are contained in the scene.
+        // (I.e. the mesh primitive and its accessors, and the material 
+        // and its textures)
+        GltfModelBuilder gltfModelBuilder = GltfModelBuilder.create();
+        gltfModelBuilder.addSceneModel(sceneModel);
+        gltfModelBuilder.addAnimationModel(animationModel);
+        DefaultGltfModel gltfModel = gltfModelBuilder.build();
+
+        return gltfModel;
+    }
+
+    /**
+     * Create a simple unit square mesh primitive
+     * 
+     * @return The mesh primitive
+     */
+    private static DefaultMeshPrimitiveModel createUnitSquare()
+    {
+        // Create a mesh primitive
+        int indices[] = { 0, 1, 2, 1, 3, 2 };
+        // @formatter:off
+        float[] positions = new float[]
+        {   
+            0.0f, 0.0f, 0.0f, 
+            1.0f, 0.0f, 0.0f, 
+            0.0f, 1.0f, 0.0f,
+            1.0f, 1.0f, 0.0f 
+        };
+        // @formatter:on
+
+        DefaultMeshPrimitiveModel meshPrimitiveModel =
+            MeshPrimitiveModels.create(indices, positions, null, null);
+
+        // Create a material, and assign it to the mesh primitive
+        PbrMaterialModel materialModel =
+            MaterialModels.createFromBaseColor(1.0f, 0.0f, 0.0f, 1.0f);
+        meshPrimitiveModel.setMaterialModel(materialModel);
+
+        return meshPrimitiveModel;
+    }
+}

--- a/jgltf-model-transform/src/main/java/de/javagl/jgltf/model/transform/GltfModelElementCollector.java
+++ b/jgltf-model-transform/src/main/java/de/javagl/jgltf/model/transform/GltfModelElementCollector.java
@@ -180,7 +180,7 @@ class GltfModelElementCollector
      */
     void process(DefaultGltfModel gltfModel)
     {
-        logger.info("Collecting elements in glTF model...");
+        logger.fine("Collecting elements in glTF model...");
 
         this.gltfModel = gltfModel;
         this.processed.clear();
@@ -212,7 +212,7 @@ class GltfModelElementCollector
 
         addModelElement(gltfModel);
         
-        logger.info("Collecting elements in glTF model DONE");
+        logger.fine("Collecting elements in glTF model DONE");
     }
 
     /**
@@ -335,7 +335,7 @@ class GltfModelElementCollector
             boolean added = set.add(d);
             if (added)
             {
-                logger.info("Adding missing model: " + modelElement);
+                logger.fine("Adding missing model: " + modelElement);
                 adder.accept(gltfModel, d);
             }
         }

--- a/jgltf-model-transform/src/main/java/de/javagl/jgltf/model/transform/GltfModelPruner.java
+++ b/jgltf-model-transform/src/main/java/de/javagl/jgltf/model/transform/GltfModelPruner.java
@@ -66,13 +66,14 @@ class GltfModelPruner
     static void prune(DefaultGltfModel gltfModel,
         Collection<? extends ModelElement> toRemove)
     {
-        Level level = Level.INFO;
+        Level level = Level.FINE;
 
-        logger.info("Building model graph...");
+        logger.log(level, "Building model graph...");
 
         ModelGraph g = ModelGraphs.build(gltfModel);
 
-        logger.info("Building model graph DONE");
+        logger.log(level, "Building model graph DONE");
+
         if (logger.isLoggable(level))
         {
             //logger.log(level, Graphs.createString(g));
@@ -143,7 +144,7 @@ class GltfModelPruner
             // If there is nothing to remove, stop the iteration
             if (currentToRemove.isEmpty())
             {
-                logger.info("No more elements to remove after iteration "
+                logger.log(level, "No more elements to remove after iteration "
                     + iteration + ", DONE");
                 break;
             }
@@ -183,7 +184,7 @@ class GltfModelPruner
                 g.removeVertex(v);
             }
 
-            logger.info("Iteration " + iteration + " DONE");
+            logger.log(level, "Iteration " + iteration + " DONE");
             iteration++;
         }
     }

--- a/jgltf-model-transform/src/test/java/de/javagl/jgltf/model/transform/test/GltfModelTransformsTest.java
+++ b/jgltf-model-transform/src/test/java/de/javagl/jgltf/model/transform/test/GltfModelTransformsTest.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.logging.Logger;
 
 import de.javagl.jgltf.model.MeshPrimitiveModel;
 import de.javagl.jgltf.model.ModelElement;
@@ -28,6 +29,12 @@ import de.javagl.jgltf.model.transform.GltfModelTransforms;
  */
 public class GltfModelTransformsTest
 {
+    /**
+     * The logger used in this class
+     */
+    private static final Logger logger =
+        Logger.getLogger(GltfModelTransformsTest.class.getName());
+    
     /**
      * The base directory for the files that are written
      */
@@ -267,6 +274,9 @@ public class GltfModelTransformsTest
     {
         File originalFile = prepareOutput(name, ".glb");
         File modifiedFile = prepareOutput(modifiedName, ".gltf");
+        
+        logger.info("Transforming " + name);
+        logger.info("        into " + modifiedName);
 
         GltfModelWriter w = new GltfModelWriter();
         w.writeBinary(gltfModel, originalFile);

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/MathUtils.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/MathUtils.java
@@ -326,6 +326,40 @@ public class MathUtils
     }
     
     /**
+     * Fills the given array with the values for a scalar-last quaternion that
+     * describes the rotation around the specified axis, about the given 
+     * angle in radians.
+     * 
+     * @param x The x-component of the axis
+     * @param y The y-component of the axis
+     * @param z The z-component of the axis
+     * @param angleRad The angle, in radians
+     * @param q The quaternion
+     */
+    public static void axisAngleRadToQuaternion(double x,
+        double y, double z, double angleRad, double q[])
+    {
+        double halfAngleRad = angleRad * 0.5f;
+        double s = Math.sin(halfAngleRad);
+
+        double lenSquared = x * x + y * y + z * z;
+        if (lenSquared < EPSILON)
+        {
+            q[0] = 0.0;
+            q[1] = 0.0;
+            q[2] = 0.0;
+            q[3] = 1.0;
+            return;
+        }
+
+        double invLen = 1.0 / Math.sqrt(lenSquared);
+        q[0] = x * invLen * s;
+        q[1] = y * invLen * s;
+        q[2] = z * invLen * s;
+        q[3] = Math.cos(halfAngleRad);
+    }
+    
+    /**
      * Inverts the given matrix and writes the result into the given target
      * matrix. If the given matrix is not invertible, then the target matrix 
      * will be set to identity.  

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/extensions/ExtensionHandlerRegistries.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/extensions/ExtensionHandlerRegistries.java
@@ -78,7 +78,7 @@ public class ExtensionHandlerRegistries
         List<ExtensionHandler> result = new ArrayList<ExtensionHandler>();
         for (ExtensionHandler extensionHandler : extensionHandlers)
         {
-            logger.info("Found ExtensionHandler: "
+            logger.fine("Found ExtensionHandler: "
                 + extensionHandler.getExtensionName() + " for "
                 + extensionHandler.getImplClass().getSimpleName() + " as " 
                 + extensionHandler.getModelClass().getSimpleName() + " on "

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/extensions/ExtensionModels.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/extensions/ExtensionModels.java
@@ -29,6 +29,7 @@ package de.javagl.jgltf.model.extensions;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import de.javagl.jgltf.impl.v2.GlTFProperty;
@@ -51,6 +52,11 @@ public class ExtensionModels
         Logger.getLogger(ExtensionModels.class.getName());
 
     /**
+     * The log level for detailed information about the conversion
+     */
+    private static final Level detailLevel = Level.FINE;
+
+    /**
      * Call {@link ExtensionHandler#preprocess(GltfModel, ExtensionProcessing)}
      * with the given model and extension processing instance on all known
      * extension handlers.
@@ -69,23 +75,23 @@ public class ExtensionModels
         {
             extensionHandler.preprocess(gltfModel, extensionProcessing);
         }
-    }    
-    
+    }
+
     /**
-     * Process the extensions of the given model element (with the given class) 
+     * Process the extensions of the given model element (with the given class)
      * that is contained in the given glTF model.<br>
      * <br>
-     * Note: An implementation detail is that this assumes that the given model 
+     * Note: An implementation detail is that this assumes that the given model
      * element extends the {@link AbstractModelElement} class.<br>
      * <br>
-     * This will examine all extension objects that are stored in the given 
-     * {@link ModelElement}. For each extension object, it will look up
-     * an {@link ExtensionHandler} in the {@link ExtensionHandlerRegistry}.
-     * When an extension handler is found, then it will be used for 
-     * converting the extension object into its "model" representation,
-     * using {@link ExtensionHandler#convertToModel(GltfModel, Object, Object)},
-     * and add it to the {@link ModelElement#getExtensionModels()} of the
-     * model element.<br>
+     * This will examine all extension objects that are stored in the given
+     * {@link ModelElement}. For each extension object, it will look up an
+     * {@link ExtensionHandler} in the {@link ExtensionHandlerRegistry}. When an
+     * extension handler is found, then it will be used for converting the
+     * extension object into its "model" representation, using
+     * {@link ExtensionHandler#convertToModel(GltfModel, Object, Object)}, and
+     * add it to the {@link ModelElement#getExtensionModels()} of the model
+     * element.<br>
      * <br>
      * Clients can then obtain the extension model object from the model
      * element, with {@link ModelElement#getExtensionModel(String, Class)}.
@@ -94,8 +100,8 @@ public class ExtensionModels
      * @param modelElement The {@link ModelElement}
      * @param modelClass The class of the {@link ModelElement}
      */
-    public static void createExtensionModels(
-        GltfModel gltfModel, ModelElement modelElement, Class<?> modelClass)
+    public static void createExtensionModels(GltfModel gltfModel,
+        ModelElement modelElement, Class<?> modelClass)
     {
         if (!(modelElement instanceof AbstractModelElement))
         {
@@ -137,15 +143,23 @@ public class ExtensionModels
                 GltfExtensions.convertValueOptional(jsonObject, implClass);
             if (impl != null)
             {
-                Object extensionModel = extensionHandler.convertToModel(
-                    gltfModel, modelElement, impl);
-                
-                logger.info("Found extension implementation for " + extensionName);
-                logger.info("  with model class         " + modelClass);
-                logger.info("  extension handler        " + extensionHandler);
-                logger.info("  converted implementation " + impl);
-                logger.info("  to model                 " + extensionModel);
-                
+                Object extensionModel = extensionHandler
+                    .convertToModel(gltfModel, modelElement, impl);
+
+                if (logger.isLoggable(detailLevel))
+                {
+                    logger.log(detailLevel,
+                        "Found extension implementation for " + extensionName);
+                    logger.log(detailLevel,
+                        "  with model class         " + modelClass);
+                    logger.log(detailLevel,
+                        "  extension handler        " + extensionHandler);
+                    logger.log(detailLevel,
+                        "  converted implementation " + impl);
+                    logger.log(detailLevel,
+                        "  to model                 " + extensionModel);
+                }
+
                 if (extensionModel != null)
                 {
                     abstractModelElement.addExtensionModel(extensionName,
@@ -155,32 +169,31 @@ public class ExtensionModels
         }
     }
 
-    
     /**
      * Create the implementation-level representation of the given model
-     * element, to be stored in the {@link GlTFProperty#getExtensions()}
-     * of the given glTF property.<br>
+     * element, to be stored in the {@link GlTFProperty#getExtensions()} of the
+     * given glTF property.<br>
      * <br>
-     * This will examine all extension model objects that are stored in the 
-     * {@link ModelElement#getExtensionModels()} of the given 
-     * {@link ModelElement}. For each extension model object, it will look up
-     * an {@link ExtensionHandler} in the {@link ExtensionHandlerRegistry}.
-     * When an extension handler is found, then it will be used for 
-     * converting the extension model object into its "impl" representation,
-     * using {@link ExtensionHandler#convertToImpl(GltfModel, Object)},
-     * and add it to the {@link GlTFProperty#getExtensions()} of the
-     * given {@link GlTFProperty}.<br>
+     * This will examine all extension model objects that are stored in the
+     * {@link ModelElement#getExtensionModels()} of the given
+     * {@link ModelElement}. For each extension model object, it will look up an
+     * {@link ExtensionHandler} in the {@link ExtensionHandlerRegistry}. When an
+     * extension handler is found, then it will be used for converting the
+     * extension model object into its "impl" representation, using
+     * {@link ExtensionHandler#convertToImpl(GltfModel, Object)}, and add it to
+     * the {@link GlTFProperty#getExtensions()} of the given
+     * {@link GlTFProperty}.<br>
      * <br>
      * 
      * @param gltfModel The {@link GltfModel}
      * @param modelElement The {@link ModelElement}
      * @param modelClass The class of the {@link ModelElement}
-     * @param glTFProperty The {@link GlTFProperty} that will store the 
-     * implementation-level representation of the extension.
+     * @param glTFProperty The {@link GlTFProperty} that will store the
+     *        implementation-level representation of the extension.
      */
-    public static void createExtensionImpls(
-        GltfModel gltfModel, ModelElement modelElement, 
-        Class<?> modelClass, GlTFProperty glTFProperty)
+    public static void createExtensionImpls(GltfModel gltfModel,
+        ModelElement modelElement, Class<?> modelClass,
+        GlTFProperty glTFProperty)
     {
         Map<String, Object> extensionModels = modelElement.getExtensionModels();
         if (extensionModels == null || extensionModels.isEmpty())
@@ -203,35 +216,38 @@ public class ExtensionModels
             }
             logger.fine("Found extension " + extensionName
                 + " with extension handler " + extensionHandler);
-            
-            Object impl = extensionHandler.convertToImpl(
-                gltfModel, modelObject);
 
-            logger.info("Found extension model for " + extensionName);
-            logger.info("  with model class  " + modelClass);
-            logger.info("  extension handler " + extensionHandler);
-            logger.info("  converted model   " + modelElement);
-            logger.info("  to implementation " + impl);
-            
+            Object impl =
+                extensionHandler.convertToImpl(gltfModel, modelObject);
+
+            if (logger.isLoggable(detailLevel))
+            {
+                logger.log(detailLevel,
+                    "Found extension model for " + extensionName);
+                logger.log(detailLevel, "  with model class  " + modelClass);
+                logger.log(detailLevel,
+                    "  extension handler " + extensionHandler);
+                logger.log(detailLevel, "  converted model   " + modelElement);
+                logger.log(detailLevel, "  to implementation " + impl);
+            }
+
             glTFProperty.addExtensions(extensionName, impl);
         }
     }
-    
 
     /**
      * Copy all extension model elements that are contained in the given source
      * element, and add the copies to the given target.<br>
      * <br>
-     * Note: An implementation detail is that this assumes that the given target 
+     * Note: An implementation detail is that this assumes that the given target
      * element extends the {@link AbstractModelElement} class.<br>
      * <br>
-     * This will examine all extension objects that are stored in the given 
+     * This will examine all extension objects that are stored in the given
      * source {@link ModelElement}. For each extension object, it will look up
-     * an {@link ExtensionHandler} in the {@link ExtensionHandlerRegistry}.
-     * When an extension handler is found, then it will be used for 
-     * copying the extension object, using {@link ExtensionHandler#copy},
-     * and the copy to the {@link ModelElement#getExtensionModels()} of the
-     * model element.<br>
+     * an {@link ExtensionHandler} in the {@link ExtensionHandlerRegistry}. When
+     * an extension handler is found, then it will be used for copying the
+     * extension object, using {@link ExtensionHandler#copy}, and the copy to
+     * the {@link ModelElement#getExtensionModels()} of the model element.<br>
      * <br>
      * 
      * @param gltfModel The {@link GltfModel}
@@ -239,14 +255,11 @@ public class ExtensionModels
      * @param targetModelElement The target {@link ModelElement}
      * @param modelClass The class of the {@link ModelElement}
      * @param modelElementMap The mapping from source to target model elements
-     * that will be passed to {@link ExtensionHandler#copy} 
+     *        that will be passed to {@link ExtensionHandler#copy}
      */
-    public static void copyExtensionModels(
-        GltfModel gltfModel, 
-        ModelElement sourceModelElement, 
-        ModelElement targetModelElement,
-        Class<?> modelClass,
-        Map<ModelElement, ModelElement> modelElementMap)
+    public static void copyExtensionModels(GltfModel gltfModel,
+        ModelElement sourceModelElement, ModelElement targetModelElement,
+        Class<?> modelClass, Map<ModelElement, ModelElement> modelElementMap)
     {
         if (!(targetModelElement instanceof AbstractModelElement))
         {
@@ -286,7 +299,7 @@ public class ExtensionModels
                 targetExtensionModelObject);
         }
     }
-    
+
     /**
      * Private constructor to prevent instantiation
      */
@@ -294,6 +307,5 @@ public class ExtensionModels
     {
         // Private constructor to prevent instantiation
     }
-
 
 }

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/extensions/ExtensionProcessing.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/extensions/ExtensionProcessing.java
@@ -40,6 +40,12 @@ import de.javagl.jgltf.model.impl.DefaultBufferViewModel;
  * For now, this interface is tailored for the case of extensions that
  * provide the data of accessors, meaning that the accessors do not have
  * an associated buffer view (i.e. Draco compression).
+ * 
+ * TODO: The 'acceptAccessorEncoding' function should probably rather be
+ * an 'acceptBufferView(..., optionalEncodedAccessorModels)' function.
+ * Extensions may use this to add arbitrary buffer views that are outside
+ * of the buffer structure builder mechanism (and optionally say which
+ * accessors are encoded with these buffer views)
  */
 public interface ExtensionProcessing
 {


### PR DESCRIPTION
The `de.javagl.jgltf.model.creation` package contains a few helper classes for creating "model" objects. Many of them are just flat, `static` convenience methods. For some of the more complex model structures - namely, `MeshPrimitiveModel` and `MaterialModel` - there are "builder" classes that allow assembling the desired structures.

I think that it could make sense to also offer some "builder" class for _animations_. 

This PR is a **DRAFT** for an `AnimationBuilder`. This will likely not be merged in its current form. The current state should be considered as "brainstorming". 

Some of the intented usage patterns could be straightforward. An earlier (non-published) state looked like this:
```java
AnimationBuilder ab = AnimationBuilder.create();
ab.beginChannel(nodeModel);
ab.addTranslation(0.0, 0.0. 0.0, 0.0);
ab.addTranslation(1.0, 2.0. 2.0, 0.0);
ab.addTranslation(2.0, 4.0. 0.0, 4.0);
ab.endChannel();
AnimationModel a = ab.build();
```
But this is too constrained: It did not offer dedicated functions for the different interpolation methods, namely, `STEP`, `LINEAR`, `CUBICSPLINE`.

Smoothly integrating the 'spline' interpolation into such a builder is not completely straightforward, though: In this interpolation mode, each of the `add...` calls will need the "in-tangent", actual keyframe, and "out-tangent". 

I'd like to offer this in a way that prevents wrong usage patterns. It should not be possible to do
```java
ab.addTranslation(0.0, 0.0. 0.0, 0.0); // Suggests STEP or LINEAR
ab.addTranslation(1.0, 2.0. 2.0, 0.0, 1.2, 2.3, 3.4, 4.5, 5.6, 6.7); // Suggests CUBICSPLINE
```

The _vast_ majority of uses could be pretty simple, if they were constrained to animations with a single channel and a single sampler with a single interpolation mode. But it is not perfectly clear how much control the user should have over the actual structure of "channels" and "samplers" and the possibility to mix different interpolation modes.

A draft of the usage of the _current_ state here is shown in the [`GltfModelCreationAnimationExample`](https://github.com/javagl/JglTF/blob/fc8ae60c928443e2095a7fbf477508ad46c7308d/jgltf-model-builder/src/test/java/de/javagl/jgltf/model/creation/example/GltfModelCreationAnimationExample.java#L48). It does offer some form flexibility in terms of the "channels", but still doesn't allow to use the same sampler in multiple channels. And it does offer type-safety in terms of the interpolation modes, but this comes at the (high) price of exposing quite a few static classes, one for each step/linear/spline and translation/rotation/scale combination. 

I think that _some_ of this could be offered in a nicer form, but I'll try to iterate on that, and update this PR when the time is right.

The current structures do not support the animation of morph target weights. And on the one hand, this is _so_ specific that it would warrant its own builder structures. On the other hand, people might want to mix weights- and node animations. (Maybe that's rare enough to fall back to the option of assembling such animations _manualy_. None of the builder classes are using a private API after all - they are all just pure convenience functions).
