### PR TITLE
Consolidate URI handling in asset writer

### DIFF
--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/io/GltfAssetWriter.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/io/GltfAssetWriter.java
@@ -33,7 +33,11 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.logging.Logger;
 
 import de.javagl.jgltf.model.io.v1.GltfAssetV1;
 import de.javagl.jgltf.model.io.v1.GltfAssetWriterV1;
@@ -45,6 +49,12 @@ import de.javagl.jgltf.model.io.v2.GltfAssetWriterV2;
  */
 public class GltfAssetWriter
 {
+    /**
+     * The logger used in this class
+     */
+    private static final Logger logger =
+        Logger.getLogger(GltfAssetWriter.class.getName());
+    
     /**
      * Default constructor
      */
@@ -212,8 +222,8 @@ public class GltfAssetWriter
     }
 
     /**
-     * Write all {@link GltfAsset#getReferenceDatas()} to files, relative
-     * to the given file.
+     * Write all {@link GltfAsset#getReferenceDatas()} to files, relative to the
+     * given file.
      * 
      * @param gltfAsset The {@link GltfAsset}
      * @param file The base file
@@ -222,22 +232,60 @@ public class GltfAssetWriter
     private void writeReferenceDatas(GltfAsset gltfAsset, File file)
         throws IOException
     {
-        for (Entry<String, ByteBuffer> entry : 
-            gltfAsset.getReferenceDatas().entrySet())
+        Map<String, ByteBuffer> referenceDatas = gltfAsset.getReferenceDatas();
+        for (Entry<String, ByteBuffer> entry : referenceDatas.entrySet())
         {
-            String relativeUrlString = entry.getKey();
+            String rawUriString = entry.getKey();
+
+            // The space character is allowed in glTF URIs, but not
+            // part of a valid URI - replace it for the checks here
+            String uriString = rawUriString.replaceAll(" ", "%20");
+
+            if (!IO.isValidUri(uriString))
+            {
+                logger.severe("Not a valid URI: '" + uriString + "'");
+                continue;
+            }
+
+            // A data URI should never be in the referenceDatas!
+            if (IO.isDataUriString(uriString))
+            {
+                logger.severe("Found data URI as reference");
+                continue;
+            }
+
+            // Absolute URIs cannot be written - print a severe error
+            // message, but continue with the remaining entries
+            if (IO.isAbsolute(uriString))
+            {
+                logger.severe(
+                    "Found absolute URI as reference: '" + uriString + "'");
+                continue;
+            }
+
+            // Decode the URI to be used as a file name
+            String decodedUriString = IO.decodeUri(uriString);
+            // System.out.println("Decoded '"+uriString+"'");
+            // System.out.println(" to '"+decodedUriString+"'");
+
+            // Resolve the decoded URI against the containing directory
+            Path resolutionPath = file.toPath().getParent();
+            Path referenceFilePath = resolutionPath.resolve(decodedUriString);
+            File referenceFile = referenceFilePath.toFile();
+
+            // Ensure that the directory of the reference file exists
+            Path referenceDirectoryPath = referenceFilePath.getParent();
+            Files.createDirectories(referenceDirectoryPath);
+
+            // Write the actual reference file data
             ByteBuffer data = entry.getValue();
-            
-            String referenceFileName = 
-                file.toPath().getParent().resolve(relativeUrlString).toString();
             try (@SuppressWarnings("resource")
-                WritableByteChannel writableByteChannel = 
-                Channels.newChannel(new FileOutputStream(referenceFileName)))
+            WritableByteChannel writableByteChannel =
+                Channels.newChannel(new FileOutputStream(referenceFile)))
             {
                 writableByteChannel.write(data.slice());
             }
         }
     }
-    
-    
+
 }

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/io/IO.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/io/IO.java
@@ -31,21 +31,31 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Base64;
+import java.util.logging.Logger;
 
 /**
  * IO utility methods
  */
 public class IO
 {
+    /**
+     * The logger used in this class
+     */
+    private static final Logger logger =
+        Logger.getLogger(IO.class.getName());
+    
     /**
      * Convert the given URI string into an absolute URI, resolving it
      * against the given base URI if necessary
@@ -60,6 +70,8 @@ public class IO
     {
         try
         {
+            // The URI string may contain the space character. Escape
+            // this to make it a valid URI string
             String escapedUriString = uriString.replaceAll(" ", "%20");
             URI uri = new URI(escapedUriString);
             if (uri.isAbsolute())
@@ -103,6 +115,78 @@ public class IO
         }
     }
 
+    
+    /**
+     * Returns whether the given string is a valid URI string.
+     * 
+     * Note that this will return <code>false</code> if the given string
+     * contains a space character.
+     * 
+     * @param uriString The URI string
+     * @return Whether the string is a valid URI string.
+     */
+    public static boolean isValidUri(String uriString)
+    {
+        try
+        {
+            URI.create(uriString);
+            return true;
+        }
+        catch (IllegalArgumentException e)
+        {
+            logger.finer(
+                "Note a valid URI: '" + uriString + "', " + e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Returns whether the given string is an absolute URI.
+     * 
+     * Note that this will print a warning and return <code>false</code> when
+     * the given string is not a valid URI string, as of
+     * {@link #isValidUri(String)}
+     * 
+     * @param uriString The URI string
+     * @return Whether the string is an absolute URI
+     */
+    public static boolean isAbsolute(String uriString)
+    {
+        try
+        {
+            URI uri = URI.create(uriString);
+            return uri.isAbsolute();
+        }
+        catch (IllegalArgumentException e)
+        {
+            logger.warning(
+                "Note a valid URI: '" + uriString + "', " + e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Perform a standard UTF-8 URI decoding on the given string.
+     * 
+     * @param uriString The URI string
+     * @return The result
+     */
+    public static String decodeUri(String uriString)
+    {
+        try
+        {
+            String encoding = StandardCharsets.UTF_8.name();
+            String result = URLDecoder.decode(uriString, encoding);
+            return result;
+        }
+        catch (UnsupportedEncodingException e)
+        {
+            // Can not happen
+            throw new IllegalArgumentException(
+                "Could not decode URI string: " + e.getMessage());
+        }
+    }
+    
     /**
      * Returns the URI describing the parent of the given URI. If the 
      * given URI describes a file, this will return the URI of the 


### PR DESCRIPTION
There are currently some considerations about how to resolve https://github.com/KhronosGroup/glTF/issues/2245

Some aspects of the URI handling in the `GltfAssetWriter` have not been very clean or convenient. This includes questions related to the linked issue, but also refers to the fact that writing an asset with a texture/image URI like
`subdirectory/image.png`
caused an error when that subdirectory did not exist.

This PR is supposed to clean this up a little. Opening as a draft, because some details may still change, and tests may have to be added

(It's also not really related to 'extension-support', but rather something that should go into 'v3.0.0-dev', but I'll have to sync the 'extension-support' branch into 'v3.0.0-dev' at some point anyhow...)
