### PR TITLE
Consistency for material and texture infos

### DIFF
--- a/jgltf-model-builder/src/main/java/de/javagl/jgltf/model/creation/MaterialBuilder.java
+++ b/jgltf-model-builder/src/main/java/de/javagl/jgltf/model/creation/MaterialBuilder.java
@@ -116,7 +116,7 @@ public class MaterialBuilder
         DefaultTextureInfoModel textureInfo = new DefaultTextureInfoModel();
         textureInfo.setTextureModel(baseColorTexture);
         textureInfo.setTexCoord(texCoord);
-        metallicRoughnessModel.setBaseColorTextureInfoModel(textureInfo);
+        metallicRoughnessModel.setBaseColorTexture(textureInfo);
         materialModel.setPbrMetallicRoughnessModel(metallicRoughnessModel);
         return this;
     }
@@ -167,7 +167,7 @@ public class MaterialBuilder
         DefaultTextureInfoModel textureInfo = new DefaultTextureInfoModel();
         textureInfo.setTextureModel(metallicRoughnessTexture);
         textureInfo.setTexCoord(texCoord);
-        metallicRoughnessModel.setMetallicRoughnessTextureInfoModel(textureInfo);
+        metallicRoughnessModel.setMetallicRoughnessTexture(textureInfo);
         materialModel.setPbrMetallicRoughnessModel(metallicRoughnessModel);
         return this;
     }
@@ -207,7 +207,7 @@ public class MaterialBuilder
         textureInfo.setTextureModel(normalTexture);
         textureInfo.setTexCoord(texCoord);
         textureInfo.setScale(scale);
-        materialModel.setNormalTextureInfoModel(textureInfo);
+        materialModel.setNormalTexture(textureInfo);
         return this;
     }
 
@@ -246,7 +246,7 @@ public class MaterialBuilder
         textureInfo.setTextureModel(occlusionTexture);
         textureInfo.setTexCoord(texCoord);
         textureInfo.setStrength(strength);
-        materialModel.setOcclusionTextureInfoModel(textureInfo);
+        materialModel.setOcclusionTexture(textureInfo);
         return this;
     }
 
@@ -288,7 +288,7 @@ public class MaterialBuilder
             new DefaultTextureInfoModel();
         textureInfo.setTextureModel(emissiveTexture);
         textureInfo.setTexCoord(texCoord);
-        materialModel.setEmissiveTextureInfoModel(textureInfo);
+        materialModel.setEmissiveTexture(textureInfo);
         materialModel.setEmissiveFactor(new double[] { r, g, b });
         return this;
     }

--- a/jgltf-model-khr-materials-anisotropy/src/main/java/de/javagl/jgltf/model/khr/materials_anisotropy/DefaultMaterialsAnisotropyModel.java
+++ b/jgltf-model-khr-materials-anisotropy/src/main/java/de/javagl/jgltf/model/khr/materials_anisotropy/DefaultMaterialsAnisotropyModel.java
@@ -36,96 +36,98 @@ import de.javagl.jgltf.model.impl.AbstractModelElement;
 /**
  * Default implementation of a {@link MaterialsAnisotropyModel}
  */
-public class DefaultMaterialsAnisotropyModel 
-    extends AbstractModelElement 
+public class DefaultMaterialsAnisotropyModel extends AbstractModelElement
     implements MaterialsAnisotropyModel
 {
     /**
-     * The anisotropy strength. (optional)<br> 
-     * Default: 0.0<br> 
-     * Minimum: 0.0 (inclusive)<br> 
-     * Maximum: 1.0 (inclusive) 
+     * The anisotropy strength. (optional)<br>
+     * Default: 0.0<br>
+     * Minimum: 0.0 (inclusive)<br>
+     * Maximum: 1.0 (inclusive)
      * 
      */
     private Double anisotropyStrength;
     /**
-     * The rotation of the anisotropy. (optional)<br> 
-     * Default: 0.0 
+     * The rotation of the anisotropy. (optional)<br>
+     * Default: 0.0
      * 
      */
     private Double anisotropyRotation;
     /**
-     * The anisotropy texture. (optional) 
+     * The anisotropy texture. (optional)
      * 
      */
-    private TextureInfoModel anisotropyTextureInfoModel;
+    private TextureInfoModel anisotropyTexture;
 
     @Override
-    public void setAnisotropyStrength(Double anisotropyStrength) {
+    public void setAnisotropyStrength(Double anisotropyStrength)
+    {
         this.anisotropyStrength = anisotropyStrength;
     }
 
     @Override
-    public Double getAnisotropyStrength() {
+    public Double getAnisotropyStrength()
+    {
         return this.anisotropyStrength;
     }
 
     @Override
-    public void setAnisotropyRotation(Double anisotropyRotation) {
+    public void setAnisotropyRotation(Double anisotropyRotation)
+    {
         this.anisotropyRotation = anisotropyRotation;
     }
 
     @Override
-    public Double getAnisotropyRotation() {
+    public Double getAnisotropyRotation()
+    {
         return this.anisotropyRotation;
     }
 
-
     @Override
-    public void setAnisotropyTextureInfoModel(TextureInfoModel anisotropyTextureInfoModel) {
-        this.anisotropyTextureInfoModel = anisotropyTextureInfoModel;
+    public void setAnisotropyTexture(TextureInfoModel anisotropyTexture)
+    {
+        this.anisotropyTexture = anisotropyTexture;
     }
 
     @Override
-    public TextureInfoModel getAnisotropyTextureInfoModel() {
-        return this.anisotropyTextureInfoModel;
+    public TextureInfoModel getAnisotropyTexture()
+    {
+        return this.anisotropyTexture;
     }
 
-    
     @Override
     public Set<ModelElement> getReferencedModelElements()
     {
-        Set<ModelElement> modelElements = 
-            getReferencedExtensionModelElements();
-        if (anisotropyTextureInfoModel != null)
+        Set<ModelElement> modelElements = getReferencedExtensionModelElements();
+        if (anisotropyTexture != null)
         {
-            modelElements.add(anisotropyTextureInfoModel);
+            modelElements.add(anisotropyTexture);
         }
         return modelElements;
     }
-    
+
     @Override
     public boolean removeModelElements(
-        Collection<? extends ModelElement> modelElementsToRemove) 
+        Collection<? extends ModelElement> modelElementsToRemove)
     {
         removeExtensionModelElements(modelElementsToRemove);
-        if (modelElementsToRemove.contains(anisotropyTextureInfoModel)) 
+        if (modelElementsToRemove.contains(anisotropyTexture))
         {
-            setAnisotropyTextureInfoModel(null);
+            setAnisotropyTexture(null);
         }
         return false;
     }
-    
+
     @Override
     public String getExtensionName()
     {
         return "KHR_materials_anisotropy";
     }
-    
+
     @Override
     public boolean isRequired()
     {
         return false;
     }
-    
+
 }

--- a/jgltf-model-khr-materials-anisotropy/src/main/java/de/javagl/jgltf/model/khr/materials_anisotropy/MaterialsAnisotropyExtensionHandler.java
+++ b/jgltf-model-khr-materials-anisotropy/src/main/java/de/javagl/jgltf/model/khr/materials_anisotropy/MaterialsAnisotropyExtensionHandler.java
@@ -80,24 +80,23 @@ public class MaterialsAnisotropyExtensionHandler implements ExtensionHandler
         DefaultMaterialsAnisotropyModel model =
             new DefaultMaterialsAnisotropyModel();
         MaterialMaterialsAnisotropy impl = (MaterialMaterialsAnisotropy) object;
-        ModelElementsV2.transferGltfPropertyElementsToModel(
-            impl, model);
+        ModelElementsV2.transferGltfPropertyElementsToModel(impl, model);
 
         List<TextureModel> textureModels = gltfModel.getTextureModels();
 
         model.setAnisotropyStrength(impl.getAnisotropyStrength());
         model.setAnisotropyRotation(impl.getAnisotropyRotation());
-        
+
         TextureInfo anisotropyTextureInfo = impl.getAnisotropyTexture();
         if (anisotropyTextureInfo != null)
         {
-            DefaultTextureInfoModel anisotropyTextureInfoModel = 
+            DefaultTextureInfoModel anisotropyTextureInfoModel =
                 TextureInfoModels.from(textureModels, anisotropyTextureInfo);
-            model.setAnisotropyTextureInfoModel(anisotropyTextureInfoModel);
-            ExtensionModels.createExtensionModels(gltfModel, 
+            model.setAnisotropyTexture(anisotropyTextureInfoModel);
+            ExtensionModels.createExtensionModels(gltfModel,
                 anisotropyTextureInfoModel, TextureInfoModel.class);
         }
-        
+
         return model;
     }
 
@@ -105,50 +104,45 @@ public class MaterialsAnisotropyExtensionHandler implements ExtensionHandler
     public Object convertToImpl(GltfModel gltfModel, Object modelObject)
     {
         DefaultMaterialsAnisotropyModel model =
-            (DefaultMaterialsAnisotropyModel)modelObject;
+            (DefaultMaterialsAnisotropyModel) modelObject;
         MaterialMaterialsAnisotropy impl = new MaterialMaterialsAnisotropy();
-        ModelElementsV2.transferGltfPropertyElementsFromModel(
-            model, impl);
+        ModelElementsV2.transferGltfPropertyElementsFromModel(model, impl);
 
         impl.setAnisotropyStrength(model.getAnisotropyStrength());
         impl.setAnisotropyRotation(model.getAnisotropyRotation());
 
-        TextureInfoModel anisotropyTextureInfoModel = 
-            model.getAnisotropyTextureInfoModel();
-        TextureInfo anisotropyTextureInfo = 
+        TextureInfoModel anisotropyTextureInfoModel =
+            model.getAnisotropyTexture();
+        TextureInfo anisotropyTextureInfo =
             TextureInfos.from(gltfModel, anisotropyTextureInfoModel);
         impl.setAnisotropyTexture(anisotropyTextureInfo);
 
         return impl;
     }
-    
+
     @Override
     public Object copy(GltfModel gltfModel, Object modelObject,
         Map<ModelElement, ModelElement> modelElementMap)
     {
         MaterialsAnisotropyModel inputModel =
-            (MaterialsAnisotropyModel)modelObject;
-        DefaultMaterialsAnisotropyModel outputModel = 
+            (MaterialsAnisotropyModel) modelObject;
+        DefaultMaterialsAnisotropyModel outputModel =
             new DefaultMaterialsAnisotropyModel();
         modelElementMap.put(inputModel, outputModel);
-        
+
         outputModel.setAnisotropyStrength(inputModel.getAnisotropyStrength());
         outputModel.setAnisotropyRotation(inputModel.getAnisotropyRotation());
 
-        TextureInfoModel inputAnisotropyTextureInfoModel = 
-            inputModel.getAnisotropyTextureInfoModel();
-        TextureInfoModel outputAnisotropyTextureInfoModel =
-            TextureInfoModels.copy(gltfModel, 
-                inputAnisotropyTextureInfoModel, modelElementMap);
-        outputModel.setAnisotropyTextureInfoModel(
-            outputAnisotropyTextureInfoModel);
+        TextureInfoModel inputAnisotropyTextureInfoModel =
+            inputModel.getAnisotropyTexture();
+        TextureInfoModel outputAnisotropyTextureInfoModel = TextureInfoModels
+            .copy(gltfModel, inputAnisotropyTextureInfoModel, modelElementMap);
+        outputModel.setAnisotropyTexture(outputAnisotropyTextureInfoModel);
 
-        ExtensionModels.copyExtensionModels(gltfModel, inputModel,
-            outputModel, modelElementMap);
-        
+        ExtensionModels.copyExtensionModels(gltfModel, inputModel, outputModel,
+            modelElementMap);
+
         return outputModel;
     }
-    
-    
 
 }

--- a/jgltf-model-khr-materials-anisotropy/src/main/java/de/javagl/jgltf/model/khr/materials_anisotropy/MaterialsAnisotropyModel.java
+++ b/jgltf-model-khr-materials-anisotropy/src/main/java/de/javagl/jgltf/model/khr/materials_anisotropy/MaterialsAnisotropyModel.java
@@ -37,54 +37,53 @@ import de.javagl.jgltf.model.extensions.ExtensionModel;
 public interface MaterialsAnisotropyModel extends ModelElement, ExtensionModel
 {
     /**
-     * The anisotropy strength. (optional)<br> 
-     * Default: 0.0<br> 
-     * Minimum: 0.0 (inclusive)<br> 
-     * Maximum: 1.0 (inclusive) 
+     * The anisotropy strength. (optional)<br>
+     * Default: 0.0<br>
+     * Minimum: 0.0 (inclusive)<br>
+     * Maximum: 1.0 (inclusive)
      * 
      * @param anisotropyStrength The anisotropy strength to set
      */
     void setAnisotropyStrength(Double anisotropyStrength);
 
     /**
-     * The anisotropy strength. (optional)<br> 
-     * Default: 0.0<br> 
-     * Minimum: 0.0 (inclusive)<br> 
-     * Maximum: 1.0 (inclusive) 
+     * The anisotropy strength. (optional)<br>
+     * Default: 0.0<br>
+     * Minimum: 0.0 (inclusive)<br>
+     * Maximum: 1.0 (inclusive)
      * 
      * @return The anisotropy strength
      */
     Double getAnisotropyStrength();
 
     /**
-     * The rotation of the anisotropy. (optional)<br> 
-     * Default: 0.0 
+     * The rotation of the anisotropy. (optional)<br>
+     * Default: 0.0
      * 
      * @param anisotropyRotation The anisotropy rotation to set
      */
     void setAnisotropyRotation(Double anisotropyRotation);
 
     /**
-     * The rotation of the anisotropy. (optional)<br> 
-     * Default: 0.0 
+     * The rotation of the anisotropy. (optional)<br>
+     * Default: 0.0
      * 
      * @return The anisotropy rotation
      */
     Double getAnisotropyRotation();
 
     /**
-     * The anisotropy texture. (optional) 
+     * The anisotropy texture. (optional)
      * 
-     * @param anisotropyTextureInfoModel The The anisotropy texture info model
+     * @param anisotropyTexture The The anisotropy texture info model
      */
-    void setAnisotropyTextureInfoModel(
-        TextureInfoModel anisotropyTextureInfoModel);
+    void setAnisotropyTexture(TextureInfoModel anisotropyTexture);
 
     /**
-     * The anisotropy texture. (optional) 
+     * The anisotropy texture. (optional)
      * 
      * @return The anisotropy texture info model
      */
-    TextureInfoModel getAnisotropyTextureInfoModel();
+    TextureInfoModel getAnisotropyTexture();
 
 }

--- a/jgltf-model-khr-materials-clearcoat/src/main/java/de/javagl/jgltf/model/khr/materials_clearcoat/DefaultMaterialsClearcoatModel.java
+++ b/jgltf-model-khr-materials-clearcoat/src/main/java/de/javagl/jgltf/model/khr/materials_clearcoat/DefaultMaterialsClearcoatModel.java
@@ -49,7 +49,7 @@ public class DefaultMaterialsClearcoatModel
     /**
      * The clearcoat texture info model
      */
-    private TextureInfoModel clearcoatTextureInfoModel;
+    private TextureInfoModel clearcoatTexture;
     
     /**
      * The clearcoat layer roughness.
@@ -59,12 +59,12 @@ public class DefaultMaterialsClearcoatModel
     /**
      * The clearcoat layer roughness texture info
      */
-    private TextureInfoModel clearcoatRoughnessTextureInfoModel;
+    private TextureInfoModel clearcoatRoughnessTexture;
 
     /**
      * The clearcoat normal map texture info
      */
-    private NormalTextureInfoModel clearcoatNormalTextureInfoModel;
+    private NormalTextureInfoModel clearcoatNormalTexture;
 
     @Override
     public void setClearcoatFactor(Double clearcoatFactor)
@@ -79,16 +79,16 @@ public class DefaultMaterialsClearcoatModel
     }
 
     @Override
-    public void setClearcoatTextureInfoModel(
-        TextureInfoModel clearcoatTextureInfoModel)
+    public void setClearcoatTexture(
+        TextureInfoModel clearcoatTexture)
     {
-        this.clearcoatTextureInfoModel = clearcoatTextureInfoModel;
+        this.clearcoatTexture = clearcoatTexture;
     }
 
     @Override
-    public TextureInfoModel getClearcoatTextureInfoModel()
+    public TextureInfoModel getClearcoatTexture()
     {
-        return this.clearcoatTextureInfoModel;
+        return this.clearcoatTexture;
     }
 
     @Override
@@ -104,30 +104,30 @@ public class DefaultMaterialsClearcoatModel
     }
 
     @Override
-    public void setClearcoatRoughnessTextureInfoModel(
-        TextureInfoModel clearcoatRoughnessTextureInfoModel)
+    public void setClearcoatRoughnessTexture(
+        TextureInfoModel clearcoatRoughnessTexture)
     {
-        this.clearcoatRoughnessTextureInfoModel = 
-            clearcoatRoughnessTextureInfoModel;
+        this.clearcoatRoughnessTexture = 
+            clearcoatRoughnessTexture;
     }
 
     @Override
-    public TextureInfoModel getClearcoatRoughnessTextureInfoModel()
+    public TextureInfoModel getClearcoatRoughnessTexture()
     {
-        return this.clearcoatRoughnessTextureInfoModel;
+        return this.clearcoatRoughnessTexture;
     }
 
     @Override
-    public void setClearcoatNormalTextureInfoModel(
-        NormalTextureInfoModel clearcoatNormalTextureInfoModel)
+    public void setClearcoatNormalTexture(
+        NormalTextureInfoModel clearcoatNormalTexture)
     {
-        this.clearcoatNormalTextureInfoModel = clearcoatNormalTextureInfoModel;
+        this.clearcoatNormalTexture = clearcoatNormalTexture;
     }
 
     @Override
-    public NormalTextureInfoModel getClearcoatNormalTextureInfoModel()
+    public NormalTextureInfoModel getClearcoatNormalTexture()
     {
-        return this.clearcoatNormalTextureInfoModel;
+        return this.clearcoatNormalTexture;
     }
     
     @Override
@@ -135,17 +135,17 @@ public class DefaultMaterialsClearcoatModel
     {
         Set<ModelElement> modelElements = 
             getReferencedExtensionModelElements();
-        if (clearcoatTextureInfoModel != null)
+        if (clearcoatTexture != null)
         {
-            modelElements.add(clearcoatTextureInfoModel);
+            modelElements.add(clearcoatTexture);
         }
-        if (clearcoatRoughnessTextureInfoModel != null)
+        if (clearcoatRoughnessTexture != null)
         {
-            modelElements.add(clearcoatRoughnessTextureInfoModel);
+            modelElements.add(clearcoatRoughnessTexture);
         }
-        if (clearcoatNormalTextureInfoModel != null)
+        if (clearcoatNormalTexture != null)
         {
-            modelElements.add(clearcoatNormalTextureInfoModel);
+            modelElements.add(clearcoatNormalTexture);
         }
         return modelElements;
     }
@@ -155,17 +155,17 @@ public class DefaultMaterialsClearcoatModel
         Collection<? extends ModelElement> modelElementsToRemove) 
     {
         removeExtensionModelElements(modelElementsToRemove);
-        if (modelElementsToRemove.contains(clearcoatTextureInfoModel)) 
+        if (modelElementsToRemove.contains(clearcoatTexture)) 
         {
-            setClearcoatTextureInfoModel(null);
+            setClearcoatTexture(null);
         }
-        if (modelElementsToRemove.contains(clearcoatRoughnessTextureInfoModel)) 
+        if (modelElementsToRemove.contains(clearcoatRoughnessTexture)) 
         {
-            setClearcoatRoughnessTextureInfoModel(null);
+            setClearcoatRoughnessTexture(null);
         }
-        if (modelElementsToRemove.contains(clearcoatNormalTextureInfoModel)) 
+        if (modelElementsToRemove.contains(clearcoatNormalTexture)) 
         {
-            setClearcoatNormalTextureInfoModel(null);
+            setClearcoatNormalTexture(null);
         }
         return false;
     }

--- a/jgltf-model-khr-materials-clearcoat/src/main/java/de/javagl/jgltf/model/khr/materials_clearcoat/MaterialsClearcoatExtensionHandler.java
+++ b/jgltf-model-khr-materials-clearcoat/src/main/java/de/javagl/jgltf/model/khr/materials_clearcoat/MaterialsClearcoatExtensionHandler.java
@@ -83,8 +83,7 @@ public class MaterialsClearcoatExtensionHandler implements ExtensionHandler
         DefaultMaterialsClearcoatModel model =
             new DefaultMaterialsClearcoatModel();
         MaterialMaterialsClearcoat impl = (MaterialMaterialsClearcoat) object;
-        ModelElementsV2.transferGltfPropertyElementsToModel(
-            impl, model);
+        ModelElementsV2.transferGltfPropertyElementsToModel(impl, model);
 
         List<TextureModel> textureModels = gltfModel.getTextureModels();
 
@@ -92,23 +91,22 @@ public class MaterialsClearcoatExtensionHandler implements ExtensionHandler
         TextureInfo clearcoatTextureInfo = impl.getClearcoatTexture();
         if (clearcoatTextureInfo != null)
         {
-            DefaultTextureInfoModel clearcoatTextureInfoModel = 
+            DefaultTextureInfoModel clearcoatTextureInfoModel =
                 TextureInfoModels.from(textureModels, clearcoatTextureInfo);
-            model.setClearcoatTextureInfoModel(clearcoatTextureInfoModel);
-            ExtensionModels.createExtensionModels(gltfModel, 
+            model.setClearcoatTexture(clearcoatTextureInfoModel);
+            ExtensionModels.createExtensionModels(gltfModel,
                 clearcoatTextureInfoModel, TextureInfoModel.class);
         }
 
-        model.setClearcoatRoughnessFactor(
-            impl.getClearcoatRoughnessFactor());
+        model.setClearcoatRoughnessFactor(impl.getClearcoatRoughnessFactor());
         TextureInfo clearcoatRoughnessTextureInfo =
             impl.getClearcoatRoughnessTexture();
         if (clearcoatRoughnessTextureInfo != null)
         {
             DefaultTextureInfoModel clearcoatRoughnessTextureInfoModel =
-                TextureInfoModels.from(
-                    textureModels, clearcoatRoughnessTextureInfo);
-            model.setClearcoatRoughnessTextureInfoModel(
+                TextureInfoModels.from(textureModels,
+                    clearcoatRoughnessTextureInfo);
+            model.setClearcoatRoughnessTexture(
                 clearcoatRoughnessTextureInfoModel);
             ExtensionModels.createExtensionModels(gltfModel,
                 clearcoatRoughnessTextureInfoModel, TextureInfoModel.class);
@@ -119,11 +117,10 @@ public class MaterialsClearcoatExtensionHandler implements ExtensionHandler
         if (clearcoatNormalTextureInfo != null)
         {
             DefaultNormalTextureInfoModel clearcoatNormalTextureInfoModel =
-                TextureInfoModels.from(
-                    textureModels, clearcoatNormalTextureInfo);
-            model.setClearcoatNormalTextureInfoModel(
-                clearcoatNormalTextureInfoModel);
-            ExtensionModels.createExtensionModels(gltfModel, 
+                TextureInfoModels.from(textureModels,
+                    clearcoatNormalTextureInfo);
+            model.setClearcoatNormalTexture(clearcoatNormalTextureInfoModel);
+            ExtensionModels.createExtensionModels(gltfModel,
                 clearcoatNormalTextureInfoModel, TextureInfoModel.class);
         }
         return model;
@@ -133,79 +130,74 @@ public class MaterialsClearcoatExtensionHandler implements ExtensionHandler
     public Object convertToImpl(GltfModel gltfModel, Object modelObject)
     {
         DefaultMaterialsClearcoatModel model =
-            (DefaultMaterialsClearcoatModel)modelObject;
+            (DefaultMaterialsClearcoatModel) modelObject;
         MaterialMaterialsClearcoat impl = new MaterialMaterialsClearcoat();
-        ModelElementsV2.transferGltfPropertyElementsFromModel(
-            model, impl);
+        ModelElementsV2.transferGltfPropertyElementsFromModel(model, impl);
 
         impl.setClearcoatFactor(model.getClearcoatFactor());
         impl.setClearcoatRoughnessFactor(model.getClearcoatRoughnessFactor());
 
-        TextureInfoModel clearcoatTextureInfoModel = 
-            model.getClearcoatTextureInfoModel();
-        TextureInfo clearcoatTextureInfo = 
+        TextureInfoModel clearcoatTextureInfoModel =
+            model.getClearcoatTexture();
+        TextureInfo clearcoatTextureInfo =
             TextureInfos.from(gltfModel, clearcoatTextureInfoModel);
         impl.setClearcoatTexture(clearcoatTextureInfo);
 
         TextureInfoModel clearcoatRoughnessTextureInfoModel =
-            model.getClearcoatRoughnessTextureInfoModel();
-        TextureInfo clearcoatRoughnessTextureInfo = TextureInfos.from(
-            gltfModel, clearcoatRoughnessTextureInfoModel);
+            model.getClearcoatRoughnessTexture();
+        TextureInfo clearcoatRoughnessTextureInfo =
+            TextureInfos.from(gltfModel, clearcoatRoughnessTextureInfoModel);
         impl.setClearcoatRoughnessTexture(clearcoatRoughnessTextureInfo);
-        
+
         NormalTextureInfoModel clearcoatNormalTextureInfoModel =
-            model.getClearcoatNormalTextureInfoModel();
-        MaterialNormalTextureInfo clearcoatNormalTextureInfo = 
+            model.getClearcoatNormalTexture();
+        MaterialNormalTextureInfo clearcoatNormalTextureInfo =
             TextureInfos.from(gltfModel, clearcoatNormalTextureInfoModel);
         impl.setClearcoatNormalTexture(clearcoatNormalTextureInfo);
-        
+
         return impl;
     }
-    
+
     @Override
     public Object copy(GltfModel gltfModel, Object modelObject,
         Map<ModelElement, ModelElement> modelElementMap)
     {
         MaterialsClearcoatModel inputModel =
-            (MaterialsClearcoatModel)modelObject;
-        DefaultMaterialsClearcoatModel outputModel = 
+            (MaterialsClearcoatModel) modelObject;
+        DefaultMaterialsClearcoatModel outputModel =
             new DefaultMaterialsClearcoatModel();
         modelElementMap.put(inputModel, outputModel);
-        
+
         outputModel.setClearcoatFactor(inputModel.getClearcoatFactor());
         outputModel.setClearcoatRoughnessFactor(
             inputModel.getClearcoatRoughnessFactor());
 
-        TextureInfoModel inputClearcoatTextureInfoModel = 
-            inputModel.getClearcoatTextureInfoModel();
-        TextureInfoModel outputClearcoatTextureInfoModel =
-            TextureInfoModels.copy(gltfModel, 
-                inputClearcoatTextureInfoModel, modelElementMap);
-        outputModel.setClearcoatTextureInfoModel(
-            outputClearcoatTextureInfoModel);
+        TextureInfoModel inputClearcoatTextureInfoModel =
+            inputModel.getClearcoatTexture();
+        TextureInfoModel outputClearcoatTextureInfoModel = TextureInfoModels
+            .copy(gltfModel, inputClearcoatTextureInfoModel, modelElementMap);
+        outputModel.setClearcoatTexture(outputClearcoatTextureInfoModel);
 
         TextureInfoModel inputClearcoatRoughnessTextureInfoModel =
-            inputModel.getClearcoatRoughnessTextureInfoModel();
-        TextureInfoModel outputClearcoatRoughnessTextureInfoModel = 
-            TextureInfoModels.copy(gltfModel, 
+            inputModel.getClearcoatRoughnessTexture();
+        TextureInfoModel outputClearcoatRoughnessTextureInfoModel =
+            TextureInfoModels.copy(gltfModel,
                 inputClearcoatRoughnessTextureInfoModel, modelElementMap);
-        outputModel.setClearcoatRoughnessTextureInfoModel(
+        outputModel.setClearcoatRoughnessTexture(
             outputClearcoatRoughnessTextureInfoModel);
-        
+
         NormalTextureInfoModel inputClearcoatNormalTextureInfoModel =
-            inputModel.getClearcoatNormalTextureInfoModel();
+            inputModel.getClearcoatNormalTexture();
         NormalTextureInfoModel outputClearcoatNormalTextureInfoModel =
-            TextureInfoModels.copy(gltfModel, 
+            TextureInfoModels.copy(gltfModel,
                 inputClearcoatNormalTextureInfoModel, modelElementMap);
-        outputModel.setClearcoatNormalTextureInfoModel(
-            outputClearcoatNormalTextureInfoModel);
-        
-        ExtensionModels.copyExtensionModels(gltfModel, inputModel,
-            outputModel, modelElementMap);
-        
+        outputModel
+            .setClearcoatNormalTexture(outputClearcoatNormalTextureInfoModel);
+
+        ExtensionModels.copyExtensionModels(gltfModel, inputModel, outputModel,
+            modelElementMap);
+
         return outputModel;
     }
-    
-    
 
 }

--- a/jgltf-model-khr-materials-clearcoat/src/main/java/de/javagl/jgltf/model/khr/materials_clearcoat/MaterialsClearcoatModel.java
+++ b/jgltf-model-khr-materials-clearcoat/src/main/java/de/javagl/jgltf/model/khr/materials_clearcoat/MaterialsClearcoatModel.java
@@ -38,87 +38,86 @@ import de.javagl.jgltf.model.extensions.ExtensionModel;
 public interface MaterialsClearcoatModel extends ModelElement, ExtensionModel
 {
     /**
-     * The clearcoat layer intensity. (optional)<br> 
-     * Default: 0.0<br> 
-     * Minimum: 0.0 (inclusive)<br> 
-     * Maximum: 1.0 (inclusive) 
+     * The clearcoat layer intensity. (optional)<br>
+     * Default: 0.0<br>
+     * Minimum: 0.0 (inclusive)<br>
+     * Maximum: 1.0 (inclusive)
      * 
      * @param clearcoatFactor The clearcoatFactor to set
      */
     void setClearcoatFactor(Double clearcoatFactor);
 
     /**
-     * The clearcoat layer intensity. (optional)<br> 
-     * Default: 0.0<br> 
-     * Minimum: 0.0 (inclusive)<br> 
-     * Maximum: 1.0 (inclusive) 
+     * The clearcoat layer intensity. (optional)<br>
+     * Default: 0.0<br>
+     * Minimum: 0.0 (inclusive)<br>
+     * Maximum: 1.0 (inclusive)
      * 
      * @return The clearcoatFactor
      */
     Double getClearcoatFactor();
 
     /**
-     * The clearcoat layer intensity texture. (optional) 
+     * The clearcoat layer intensity texture. (optional)
      * 
-     * @param clearcoatTextureInfoModel The texture info
+     * @param clearcoatTexture The texture info
      */
-    void setClearcoatTextureInfoModel(
-        TextureInfoModel clearcoatTextureInfoModel);
+    void setClearcoatTexture(TextureInfoModel clearcoatTexture);
 
     /**
-     * The clearcoat layer intensity texture. (optional) 
+     * The clearcoat layer intensity texture. (optional)
      * 
      * @return The texture info
      */
-    TextureInfoModel getClearcoatTextureInfoModel();
+    TextureInfoModel getClearcoatTexture();
 
     /**
-     * The clearcoat layer roughness. (optional)<br> 
-     * Default: 0.0<br> 
-     * Minimum: 0.0 (inclusive)<br> 
-     * Maximum: 1.0 (inclusive) 
+     * The clearcoat layer roughness. (optional)<br>
+     * Default: 0.0<br>
+     * Minimum: 0.0 (inclusive)<br>
+     * Maximum: 1.0 (inclusive)
      * 
      * @param clearcoatRoughnessFactor The clearcoatRoughnessFactor to set
      */
     void setClearcoatRoughnessFactor(Double clearcoatRoughnessFactor);
 
     /**
-     * The clearcoat layer roughness. (optional)<br> 
-     * Default: 0.0<br> 
-     * Minimum: 0.0 (inclusive)<br> 
-     * Maximum: 1.0 (inclusive) 
+     * The clearcoat layer roughness. (optional)<br>
+     * Default: 0.0<br>
+     * Minimum: 0.0 (inclusive)<br>
+     * Maximum: 1.0 (inclusive)
      * 
      * @return The clearcoatRoughnessFactor
      */
     Double getClearcoatRoughnessFactor();
 
     /**
-     * The clearcoat layer roughness texture. (optional) 
+     * The clearcoat layer roughness texture. (optional)
      * 
-     * @param clearcoatRoughnessTextureInfoModel The texture info
+     * @param clearcoatRoughnessTexture The texture info
      */
-    void setClearcoatRoughnessTextureInfoModel(
-        TextureInfoModel clearcoatRoughnessTextureInfoModel);
+    void setClearcoatRoughnessTexture(
+        TextureInfoModel clearcoatRoughnessTexture);
 
     /**
-     * The clearcoat layer roughness texture. (optional) 
+     * The clearcoat layer roughness texture. (optional)
      * 
      * @return The clearcoatRoughnessTexture info
      */
-    TextureInfoModel getClearcoatRoughnessTextureInfoModel();
+    TextureInfoModel getClearcoatRoughnessTexture();
 
     /**
-     * The clearcoat normal map texture. (optional) 
+     * The clearcoat normal map texture. (optional)
      * 
-     * @param clearcoatNormalTextureInfoModel The texture info
+     * @param clearcoatNormalTexture The texture info
      */
-    void setClearcoatNormalTextureInfoModel(
-        NormalTextureInfoModel clearcoatNormalTextureInfoModel);
+    void setClearcoatNormalTexture(
+        NormalTextureInfoModel clearcoatNormalTexture);
 
     /**
-     * The clearcoat normal map texture. (optional) 
+     * The clearcoat normal map texture. (optional)
      * 
      * @return The texture info
      */
-    NormalTextureInfoModel getClearcoatNormalTextureInfoModel();
+    NormalTextureInfoModel getClearcoatNormalTexture();
 }

--- a/jgltf-model-khr-materials-sheen/src/main/java/de/javagl/jgltf/model/khr/materials_sheen/DefaultMaterialsSheenModel.java
+++ b/jgltf-model-khr-materials-sheen/src/main/java/de/javagl/jgltf/model/khr/materials_sheen/DefaultMaterialsSheenModel.java
@@ -47,7 +47,7 @@ public class DefaultMaterialsSheenModel extends AbstractModelElement
     /**
      * The sheen color (RGB) texture. (optional)
      */
-    private TextureInfoModel sheenColorTextureInfoModel;
+    private TextureInfoModel sheenColorTexture;
 
     /**
      * The sheen layer roughness. (optional)<br>
@@ -57,7 +57,7 @@ public class DefaultMaterialsSheenModel extends AbstractModelElement
     /**
      * The sheen roughness (Alpha) texture. (optional)
      */
-    private TextureInfoModel sheenRoughnessTextureInfoModel;
+    private TextureInfoModel sheenRoughnessTexture;
 
     @Override
     public void setSheenColorFactor(double[] sheenColorFactor)
@@ -72,16 +72,15 @@ public class DefaultMaterialsSheenModel extends AbstractModelElement
     }
 
     @Override
-    public void setSheenColorTextureInfoModel(
-        TextureInfoModel sheenColorTextureInfoModel)
+    public void setSheenColorTexture(TextureInfoModel sheenColorTexture)
     {
-        this.sheenColorTextureInfoModel = sheenColorTextureInfoModel;
+        this.sheenColorTexture = sheenColorTexture;
     }
 
     @Override
-    public TextureInfoModel getSheenColorTextureInfoModel()
+    public TextureInfoModel getSheenColorTexture()
     {
-        return this.sheenColorTextureInfoModel;
+        return this.sheenColorTexture;
     }
 
     @Override
@@ -97,29 +96,28 @@ public class DefaultMaterialsSheenModel extends AbstractModelElement
     }
 
     @Override
-    public void setSheenRoughnessTextureInfoModel(
-        TextureInfoModel sheenRoughnessTextureInfoModel)
+    public void setSheenRoughnessTexture(TextureInfoModel sheenRoughnessTexture)
     {
-        this.sheenRoughnessTextureInfoModel = sheenRoughnessTextureInfoModel;
+        this.sheenRoughnessTexture = sheenRoughnessTexture;
     }
 
     @Override
-    public TextureInfoModel getSheenRoughnessTextureInfoModel()
+    public TextureInfoModel getSheenRoughnessTexture()
     {
-        return this.sheenRoughnessTextureInfoModel;
+        return this.sheenRoughnessTexture;
     }
 
     @Override
     public Set<ModelElement> getReferencedModelElements()
     {
         Set<ModelElement> modelElements = getReferencedExtensionModelElements();
-        if (sheenColorTextureInfoModel != null)
+        if (sheenColorTexture != null)
         {
-            modelElements.add(sheenColorTextureInfoModel);
+            modelElements.add(sheenColorTexture);
         }
-        if (sheenRoughnessTextureInfoModel != null)
+        if (sheenRoughnessTexture != null)
         {
-            modelElements.add(sheenRoughnessTextureInfoModel);
+            modelElements.add(sheenRoughnessTexture);
         }
         return modelElements;
     }
@@ -129,13 +127,13 @@ public class DefaultMaterialsSheenModel extends AbstractModelElement
         Collection<? extends ModelElement> modelElementsToRemove)
     {
         removeExtensionModelElements(modelElementsToRemove);
-        if (modelElementsToRemove.contains(sheenColorTextureInfoModel))
+        if (modelElementsToRemove.contains(sheenColorTexture))
         {
-            setSheenColorTextureInfoModel(null);
+            setSheenColorTexture(null);
         }
-        if (modelElementsToRemove.contains(sheenRoughnessTextureInfoModel))
+        if (modelElementsToRemove.contains(sheenRoughnessTexture))
         {
-            setSheenRoughnessTextureInfoModel(null);
+            setSheenRoughnessTexture(null);
         }
         return false;
     }

--- a/jgltf-model-khr-materials-sheen/src/main/java/de/javagl/jgltf/model/khr/materials_sheen/MaterialsSheenExtensionHandler.java
+++ b/jgltf-model-khr-materials-sheen/src/main/java/de/javagl/jgltf/model/khr/materials_sheen/MaterialsSheenExtensionHandler.java
@@ -90,7 +90,7 @@ public class MaterialsSheenExtensionHandler implements ExtensionHandler
         {
             DefaultTextureInfoModel sheenColorTextureInfoModel =
                 TextureInfoModels.from(textureModels, sheenColorTextureInfo);
-            model.setSheenColorTextureInfoModel(sheenColorTextureInfoModel);
+            model.setSheenColorTexture(sheenColorTextureInfoModel);
             ExtensionModels.createExtensionModels(gltfModel,
                 sheenColorTextureInfoModel, TextureInfoModel.class);
         }
@@ -102,8 +102,7 @@ public class MaterialsSheenExtensionHandler implements ExtensionHandler
             DefaultTextureInfoModel sheenRoughnessTextureInfoModel =
                 TextureInfoModels.from(textureModels,
                     sheenRoughnessTextureInfo);
-            model.setSheenRoughnessTextureInfoModel(
-                sheenRoughnessTextureInfoModel);
+            model.setSheenRoughnessTexture(sheenRoughnessTextureInfoModel);
             ExtensionModels.createExtensionModels(gltfModel,
                 sheenRoughnessTextureInfoModel, TextureInfoModel.class);
         }
@@ -122,13 +121,13 @@ public class MaterialsSheenExtensionHandler implements ExtensionHandler
         impl.setSheenRoughnessFactor(model.getSheenRoughnessFactor());
 
         TextureInfoModel sheenColorTextureInfoModel =
-            model.getSheenColorTextureInfoModel();
+            model.getSheenColorTexture();
         TextureInfo sheenColorTextureInfo =
             TextureInfos.from(gltfModel, sheenColorTextureInfoModel);
         impl.setSheenColorTexture(sheenColorTextureInfo);
 
         TextureInfoModel sheenRoughnessTextureInfoModel =
-            model.getSheenRoughnessTextureInfoModel();
+            model.getSheenRoughnessTexture();
         TextureInfo sheenRoughnessTextureInfo =
             TextureInfos.from(gltfModel, sheenRoughnessTextureInfoModel);
         impl.setSheenRoughnessTexture(sheenRoughnessTextureInfo);
@@ -151,19 +150,18 @@ public class MaterialsSheenExtensionHandler implements ExtensionHandler
             .setSheenRoughnessFactor(inputModel.getSheenRoughnessFactor());
 
         TextureInfoModel inputSheenColorTextureInfoModel =
-            inputModel.getSheenColorTextureInfoModel();
+            inputModel.getSheenColorTexture();
         TextureInfoModel outputSheenColorTextureInfoModel = TextureInfoModels
             .copy(gltfModel, inputSheenColorTextureInfoModel, modelElementMap);
-        outputModel
-            .setSheenColorTextureInfoModel(outputSheenColorTextureInfoModel);
+        outputModel.setSheenColorTexture(outputSheenColorTextureInfoModel);
 
         TextureInfoModel inputSheenRoughnessTextureInfoModel =
-            inputModel.getSheenRoughnessTextureInfoModel();
+            inputModel.getSheenRoughnessTexture();
         TextureInfoModel outputSheenRoughnessTextureInfoModel =
             TextureInfoModels.copy(gltfModel,
                 inputSheenRoughnessTextureInfoModel, modelElementMap);
-        outputModel.setSheenRoughnessTextureInfoModel(
-            outputSheenRoughnessTextureInfoModel);
+        outputModel
+            .setSheenRoughnessTexture(outputSheenRoughnessTextureInfoModel);
 
         ExtensionModels.copyExtensionModels(gltfModel, inputModel, outputModel,
             modelElementMap);

--- a/jgltf-model-khr-materials-sheen/src/main/java/de/javagl/jgltf/model/khr/materials_sheen/MaterialsSheenModel.java
+++ b/jgltf-model-khr-materials-sheen/src/main/java/de/javagl/jgltf/model/khr/materials_sheen/MaterialsSheenModel.java
@@ -37,26 +37,26 @@ import de.javagl.jgltf.model.extensions.ExtensionModel;
 public interface MaterialsSheenModel extends ModelElement, ExtensionModel
 {
     /**
-     * Color of the sheen layer (in linear space). (optional)<br> 
-     * Default: [0,0,0]<br> 
-     * Number of items: 3<br> 
-     * Array elements:<br> 
-     * &nbsp;&nbsp;The elements of this array (optional)<br> 
-     * &nbsp;&nbsp;Minimum: 0.0 (inclusive)<br> 
-     * &nbsp;&nbsp;Maximum: 1.0 (inclusive) 
+     * Color of the sheen layer (in linear space). (optional)<br>
+     * Default: [0,0,0]<br>
+     * Number of items: 3<br>
+     * Array elements:<br>
+     * &nbsp;&nbsp;The elements of this array (optional)<br>
+     * &nbsp;&nbsp;Minimum: 0.0 (inclusive)<br>
+     * &nbsp;&nbsp;Maximum: 1.0 (inclusive)
      * 
      * @param sheenColorFactor The sheenColorFactor to set
      */
     void setSheenColorFactor(double[] sheenColorFactor);
 
     /**
-     * Color of the sheen layer (in linear space). (optional)<br> 
-     * Default: [0,0,0]<br> 
-     * Number of items: 3<br> 
-     * Array elements:<br> 
-     * &nbsp;&nbsp;The elements of this array (optional)<br> 
-     * &nbsp;&nbsp;Minimum: 0.0 (inclusive)<br> 
-     * &nbsp;&nbsp;Maximum: 1.0 (inclusive) 
+     * Color of the sheen layer (in linear space). (optional)<br>
+     * Default: [0,0,0]<br>
+     * Number of items: 3<br>
+     * Array elements:<br>
+     * &nbsp;&nbsp;The elements of this array (optional)<br>
+     * &nbsp;&nbsp;Minimum: 0.0 (inclusive)<br>
+     * &nbsp;&nbsp;Maximum: 1.0 (inclusive)
      * 
      * @return The sheenColorFactor
      */
@@ -65,34 +65,33 @@ public interface MaterialsSheenModel extends ModelElement, ExtensionModel
     /**
      * The sheen color (RGB) texture. (optional)
      * 
-     * @param sheenColorTextureInfoModel The sheenColorTextureInfoModel to set
+     * @param sheenColorTexture The sheenColorTexture to set
      */
-    void setSheenColorTextureInfoModel(
-        TextureInfoModel sheenColorTextureInfoModel);
+    void setSheenColorTexture(TextureInfoModel sheenColorTexture);
 
     /**
      * The sheen color (RGB) texture. (optional)
      * 
-     * @return The sheenColorTextureInfoModel
+     * @return The sheenColorTexture
      * 
      */
-    TextureInfoModel getSheenColorTextureInfoModel();
+    TextureInfoModel getSheenColorTexture();
 
     /**
-     * The sheen layer roughness. (optional)<br> 
-     * Default: 0.0<br> 
-     * Minimum: 0.0 (inclusive)<br> 
-     * Maximum: 1.0 (inclusive) 
+     * The sheen layer roughness. (optional)<br>
+     * Default: 0.0<br>
+     * Minimum: 0.0 (inclusive)<br>
+     * Maximum: 1.0 (inclusive)
      * 
      * @param sheenRoughnessFactor The sheenRoughnessFactor to set
      */
     void setSheenRoughnessFactor(Double sheenRoughnessFactor);
 
     /**
-     * The sheen layer roughness. (optional)<br> 
-     * Default: 0.0<br> 
-     * Minimum: 0.0 (inclusive)<br> 
-     * Maximum: 1.0 (inclusive) 
+     * The sheen layer roughness. (optional)<br>
+     * Default: 0.0<br>
+     * Minimum: 0.0 (inclusive)<br>
+     * Maximum: 1.0 (inclusive)
      * 
      * @return The sheenRoughnessFactor
      */
@@ -101,19 +100,15 @@ public interface MaterialsSheenModel extends ModelElement, ExtensionModel
     /**
      * The sheen roughness (Alpha) texture. (optional)
      * 
-     * @param sheenRoughnessTextureInfoModel The sheenRoughnessTextureInfoModel
-     *        to set
-     * 
+     * @param sheenRoughnessTexture The sheenRoughnessTexture to set
      */
-    void setSheenRoughnessTextureInfoModel(
-        TextureInfoModel sheenRoughnessTextureInfoModel);
+    void setSheenRoughnessTexture(TextureInfoModel sheenRoughnessTexture);
 
     /**
      * The sheen roughness (Alpha) texture. (optional)
      * 
      * @return The sheenRoughnessTexture
-     * 
      */
-    TextureInfoModel getSheenRoughnessTextureInfoModel();
+    TextureInfoModel getSheenRoughnessTexture();
 
 }

--- a/jgltf-model-khr-materials-transmission/src/main/java/de/javagl/jgltf/model/khr/materials_transmission/DefaultMaterialsTransmissionModel.java
+++ b/jgltf-model-khr-materials-transmission/src/main/java/de/javagl/jgltf/model/khr/materials_transmission/DefaultMaterialsTransmissionModel.java
@@ -50,7 +50,7 @@ public class DefaultMaterialsTransmissionModel extends AbstractModelElement
      * sampled from the R channel. These values are linear, and will be
      * multiplied by transmissionFactor. (optional)
      */
-    private TextureInfoModel transmissionTextureInfoModel;
+    private TextureInfoModel transmissionTexture;
 
     @Override
     public void setTransmissionFactor(Double transmissionFactor)
@@ -65,25 +65,24 @@ public class DefaultMaterialsTransmissionModel extends AbstractModelElement
     }
 
     @Override
-    public void setTransmissionTextureInfoModel(
-        TextureInfoModel transmissionTextureInfoModel)
+    public void setTransmissionTexture(TextureInfoModel transmissionTexture)
     {
-        this.transmissionTextureInfoModel = transmissionTextureInfoModel;
+        this.transmissionTexture = transmissionTexture;
     }
 
     @Override
-    public TextureInfoModel getTransmissionTextureInfoModel()
+    public TextureInfoModel getTransmissionTexture()
     {
-        return this.transmissionTextureInfoModel;
+        return this.transmissionTexture;
     }
 
     @Override
     public Set<ModelElement> getReferencedModelElements()
     {
         Set<ModelElement> modelElements = getReferencedExtensionModelElements();
-        if (transmissionTextureInfoModel != null)
+        if (transmissionTexture != null)
         {
-            modelElements.add(transmissionTextureInfoModel);
+            modelElements.add(transmissionTexture);
         }
         return modelElements;
     }
@@ -93,9 +92,9 @@ public class DefaultMaterialsTransmissionModel extends AbstractModelElement
         Collection<? extends ModelElement> modelElementsToRemove)
     {
         removeExtensionModelElements(modelElementsToRemove);
-        if (modelElementsToRemove.contains(transmissionTextureInfoModel))
+        if (modelElementsToRemove.contains(transmissionTexture))
         {
-            setTransmissionTextureInfoModel(null);
+            setTransmissionTexture(null);
         }
         return false;
     }

--- a/jgltf-model-khr-materials-transmission/src/main/java/de/javagl/jgltf/model/khr/materials_transmission/MaterialsTransmissionExtensionHandler.java
+++ b/jgltf-model-khr-materials-transmission/src/main/java/de/javagl/jgltf/model/khr/materials_transmission/MaterialsTransmissionExtensionHandler.java
@@ -91,7 +91,7 @@ public class MaterialsTransmissionExtensionHandler implements ExtensionHandler
         {
             DefaultTextureInfoModel transmissionTextureInfoModel =
                 TextureInfoModels.from(textureModels, transmissionTextureInfo);
-            model.setTransmissionTextureInfoModel(transmissionTextureInfoModel);
+            model.setTransmissionTexture(transmissionTextureInfoModel);
             ExtensionModels.createExtensionModels(gltfModel,
                 transmissionTextureInfoModel, TextureInfoModel.class);
         }
@@ -110,7 +110,7 @@ public class MaterialsTransmissionExtensionHandler implements ExtensionHandler
         impl.setTransmissionFactor(model.getTransmissionFactor());
 
         TextureInfoModel transmissionTextureInfoModel =
-            model.getTransmissionTextureInfoModel();
+            model.getTransmissionTexture();
         TextureInfo transmissionTextureInfo =
             TextureInfos.from(gltfModel, transmissionTextureInfoModel);
         impl.setTransmissionTexture(transmissionTextureInfo);
@@ -131,12 +131,11 @@ public class MaterialsTransmissionExtensionHandler implements ExtensionHandler
         outputModel.setTransmissionFactor(inputModel.getTransmissionFactor());
 
         TextureInfoModel inputTransmissionTextureInfoModel =
-            inputModel.getTransmissionTextureInfoModel();
+            inputModel.getTransmissionTexture();
         TextureInfoModel outputTransmissionTextureInfoModel =
             TextureInfoModels.copy(gltfModel, inputTransmissionTextureInfoModel,
                 modelElementMap);
-        outputModel.setTransmissionTextureInfoModel(
-            outputTransmissionTextureInfoModel);
+        outputModel.setTransmissionTexture(outputTransmissionTextureInfoModel);
 
         ExtensionModels.copyExtensionModels(gltfModel, inputModel, outputModel,
             modelElementMap);

--- a/jgltf-model-khr-materials-transmission/src/main/java/de/javagl/jgltf/model/khr/materials_transmission/MaterialsTransmissionModel.java
+++ b/jgltf-model-khr-materials-transmission/src/main/java/de/javagl/jgltf/model/khr/materials_transmission/MaterialsTransmissionModel.java
@@ -37,22 +37,22 @@ import de.javagl.jgltf.model.extensions.ExtensionModel;
 public interface MaterialsTransmissionModel extends ModelElement, ExtensionModel
 {
     /**
-     * The base percentage of light transmitted through the surface. 
-     * (optional)<br> 
-     * Default: 0.0<br> 
-     * Minimum: 0.0 (inclusive)<br> 
-     * Maximum: 1.0 (inclusive) 
+     * The base percentage of light transmitted through the surface.
+     * (optional)<br>
+     * Default: 0.0<br>
+     * Minimum: 0.0 (inclusive)<br>
+     * Maximum: 1.0 (inclusive)
      * 
      * @param transmissionFactor The transmissionFactor to set
      */
     void setTransmissionFactor(Double transmissionFactor);
 
     /**
-     * The base percentage of light transmitted through the surface. 
-     * (optional)<br> 
-     * Default: 0.0<br> 
-     * Minimum: 0.0 (inclusive)<br> 
-     * Maximum: 1.0 (inclusive) 
+     * The base percentage of light transmitted through the surface.
+     * (optional)<br>
+     * Default: 0.0<br>
+     * Minimum: 0.0 (inclusive)<br>
+     * Maximum: 1.0 (inclusive)
      * 
      * @return The transmissionFactor
      */
@@ -63,10 +63,9 @@ public interface MaterialsTransmissionModel extends ModelElement, ExtensionModel
      * sampled from the R channel. These values are linear, and will be
      * multiplied by transmissionFactor. (optional)
      * 
-     * @param transmissionTextureInfoModel The transmissionTexture to set
+     * @param transmissionTexture The transmissionTexture to set
      */
-    void setTransmissionTextureInfoModel(
-        TextureInfoModel transmissionTextureInfoModel);
+    void setTransmissionTexture(TextureInfoModel transmissionTexture);
 
     /**
      * A texture that defines the transmission percentage of the surface,
@@ -75,5 +74,5 @@ public interface MaterialsTransmissionModel extends ModelElement, ExtensionModel
      * 
      * @return The transmissionTexture
      */
-    TextureInfoModel getTransmissionTextureInfoModel();
+    TextureInfoModel getTransmissionTexture();
 }

--- a/jgltf-model-khr-materials-volume/src/main/java/de/javagl/jgltf/model/khr/materials_volume/DefaultMaterialsVolumeModel.java
+++ b/jgltf-model-khr-materials-volume/src/main/java/de/javagl/jgltf/model/khr/materials_volume/DefaultMaterialsVolumeModel.java
@@ -48,7 +48,7 @@ public class DefaultMaterialsVolumeModel extends AbstractModelElement
      * Texture that defines the thickness of the volume, stored in the G
      * channel. (optional)
      */
-    private TextureInfoModel thicknessTextureInfoModel;
+    private TextureInfoModel thicknessTexture;
 
     /**
      * Average distance that light travels in the medium before interacting with
@@ -75,16 +75,15 @@ public class DefaultMaterialsVolumeModel extends AbstractModelElement
     }
 
     @Override
-    public void
-        setThicknessTextureInfoModel(TextureInfoModel thicknessTextureInfoModel)
+    public void setThicknessTexture(TextureInfoModel thicknessTexture)
     {
-        this.thicknessTextureInfoModel = thicknessTextureInfoModel;
+        this.thicknessTexture = thicknessTexture;
     }
 
     @Override
-    public TextureInfoModel getThicknessTextureInfoModel()
+    public TextureInfoModel getThicknessTexture()
     {
-        return this.thicknessTextureInfoModel;
+        return this.thicknessTexture;
     }
 
     @Override
@@ -115,9 +114,9 @@ public class DefaultMaterialsVolumeModel extends AbstractModelElement
     public Set<ModelElement> getReferencedModelElements()
     {
         Set<ModelElement> modelElements = getReferencedExtensionModelElements();
-        if (thicknessTextureInfoModel != null)
+        if (thicknessTexture != null)
         {
-            modelElements.add(thicknessTextureInfoModel);
+            modelElements.add(thicknessTexture);
         }
         return modelElements;
     }
@@ -127,9 +126,9 @@ public class DefaultMaterialsVolumeModel extends AbstractModelElement
         Collection<? extends ModelElement> modelElementsToRemove)
     {
         removeExtensionModelElements(modelElementsToRemove);
-        if (modelElementsToRemove.contains(thicknessTextureInfoModel))
+        if (modelElementsToRemove.contains(thicknessTexture))
         {
-            setThicknessTextureInfoModel(null);
+            setThicknessTexture(null);
         }
         return false;
     }

--- a/jgltf-model-khr-materials-volume/src/main/java/de/javagl/jgltf/model/khr/materials_volume/MaterialsVolumeExtensionHandler.java
+++ b/jgltf-model-khr-materials-volume/src/main/java/de/javagl/jgltf/model/khr/materials_volume/MaterialsVolumeExtensionHandler.java
@@ -92,7 +92,7 @@ public class MaterialsVolumeExtensionHandler implements ExtensionHandler
         {
             DefaultTextureInfoModel thicknessTextureInfoModel =
                 TextureInfoModels.from(textureModels, thicknessTextureInfo);
-            model.setThicknessTextureInfoModel(thicknessTextureInfoModel);
+            model.setThicknessTexture(thicknessTextureInfoModel);
             ExtensionModels.createExtensionModels(gltfModel,
                 thicknessTextureInfoModel, TextureInfoModel.class);
         }
@@ -113,7 +113,7 @@ public class MaterialsVolumeExtensionHandler implements ExtensionHandler
         impl.setAttenuationColor(Optionals.clone(model.getAttenuationColor()));
 
         TextureInfoModel thicknessTextureInfoModel =
-            model.getThicknessTextureInfoModel();
+            model.getThicknessTexture();
         TextureInfo thicknessTextureInfo =
             TextureInfos.from(gltfModel, thicknessTextureInfoModel);
         impl.setThicknessTexture(thicknessTextureInfo);
@@ -136,11 +136,10 @@ public class MaterialsVolumeExtensionHandler implements ExtensionHandler
             Optionals.clone(inputModel.getAttenuationColor()));
 
         TextureInfoModel inputThicknessTextureInfoModel =
-            inputModel.getThicknessTextureInfoModel();
+            inputModel.getThicknessTexture();
         TextureInfoModel outputThicknessTextureInfoModel = TextureInfoModels
             .copy(gltfModel, inputThicknessTextureInfoModel, modelElementMap);
-        outputModel
-            .setThicknessTextureInfoModel(outputThicknessTextureInfoModel);
+        outputModel.setThicknessTexture(outputThicknessTextureInfoModel);
 
         ExtensionModels.copyExtensionModels(gltfModel, inputModel, outputModel,
             modelElementMap);

--- a/jgltf-model-khr-materials-volume/src/main/java/de/javagl/jgltf/model/khr/materials_volume/MaterialsVolumeModel.java
+++ b/jgltf-model-khr-materials-volume/src/main/java/de/javagl/jgltf/model/khr/materials_volume/MaterialsVolumeModel.java
@@ -37,18 +37,18 @@ import de.javagl.jgltf.model.extensions.ExtensionModel;
 public interface MaterialsVolumeModel extends ModelElement, ExtensionModel
 {
     /**
-     * Thickness of the volume. (optional)<br> 
-     * Default: 0.0<br> 
-     * Minimum: 0.0 (inclusive) 
+     * Thickness of the volume. (optional)<br>
+     * Default: 0.0<br>
+     * Minimum: 0.0 (inclusive)
      * 
      * @param thicknessFactor The thicknessFactor to set
      */
     void setThicknessFactor(Double thicknessFactor);
 
     /**
-     * Thickness of the volume. (optional)<br> 
-     * Default: 0.0<br> 
-     * Minimum: 0.0 (inclusive) 
+     * Thickness of the volume. (optional)<br>
+     * Default: 0.0<br>
+     * Minimum: 0.0 (inclusive)
      * 
      * @return The thicknessFactor
      */
@@ -58,11 +58,10 @@ public interface MaterialsVolumeModel extends ModelElement, ExtensionModel
      * Texture that defines the thickness of the volume, stored in the G
      * channel. (optional)
      * 
-     * @param thicknessTextureInfoModel The thicknessTexture to set
+     * @param thicknessTexture The thicknessTexture to set
      * 
      */
-    void setThicknessTextureInfoModel(
-        TextureInfoModel thicknessTextureInfoModel);
+    void setThicknessTexture(TextureInfoModel thicknessTexture);
 
     /**
      * Texture that defines the thickness of the volume, stored in the G
@@ -71,7 +70,7 @@ public interface MaterialsVolumeModel extends ModelElement, ExtensionModel
      * @return The thicknessTexture
      * 
      */
-    TextureInfoModel getThicknessTextureInfoModel();
+    TextureInfoModel getThicknessTexture();
 
     /**
      * Average distance that light travels in the medium before interacting with
@@ -92,28 +91,28 @@ public interface MaterialsVolumeModel extends ModelElement, ExtensionModel
     Double getAttenuationDistance();
 
     /**
-     * Color that white light turns into due to absorption when reaching the 
-     * attenuation distance. (optional)<br> 
-     * Default: [1.0,1.0,1.0]<br> 
-     * Number of items: 3<br> 
-     * Array elements:<br> 
-     * &nbsp;&nbsp;The elements of this array (optional)<br> 
-     * &nbsp;&nbsp;Minimum: 0.0 (inclusive)<br> 
-     * &nbsp;&nbsp;Maximum: 1.0 (inclusive) 
+     * Color that white light turns into due to absorption when reaching the
+     * attenuation distance. (optional)<br>
+     * Default: [1.0,1.0,1.0]<br>
+     * Number of items: 3<br>
+     * Array elements:<br>
+     * &nbsp;&nbsp;The elements of this array (optional)<br>
+     * &nbsp;&nbsp;Minimum: 0.0 (inclusive)<br>
+     * &nbsp;&nbsp;Maximum: 1.0 (inclusive)
      * 
      * @param attenuationColor The attenuationColor to set
      */
     void setAttenuationColor(double[] attenuationColor);
 
     /**
-     * Color that white light turns into due to absorption when reaching the 
-     * attenuation distance. (optional)<br> 
-     * Default: [1.0,1.0,1.0]<br> 
-     * Number of items: 3<br> 
-     * Array elements:<br> 
-     * &nbsp;&nbsp;The elements of this array (optional)<br> 
-     * &nbsp;&nbsp;Minimum: 0.0 (inclusive)<br> 
-     * &nbsp;&nbsp;Maximum: 1.0 (inclusive) 
+     * Color that white light turns into due to absorption when reaching the
+     * attenuation distance. (optional)<br>
+     * Default: [1.0,1.0,1.0]<br>
+     * Number of items: 3<br>
+     * Array elements:<br>
+     * &nbsp;&nbsp;The elements of this array (optional)<br>
+     * &nbsp;&nbsp;Minimum: 0.0 (inclusive)<br>
+     * &nbsp;&nbsp;Maximum: 1.0 (inclusive)
      * 
      * @return The attenuationColor
      */

--- a/jgltf-model-transform/src/test/java/de/javagl/jgltf/model/transform/test/GltfModelTransformsTests.java
+++ b/jgltf-model-transform/src/test/java/de/javagl/jgltf/model/transform/test/GltfModelTransformsTests.java
@@ -259,7 +259,7 @@ public class GltfModelTransformsTests
             MaterialsClearcoatModel clearcoat0 = material0.getExtensionModel(
                 "KHR_materials_clearcoat", MaterialsClearcoatModel.class);
             TextureInfoModel textureInfo0 =
-                clearcoat0.getClearcoatTextureInfoModel();
+                clearcoat0.getClearcoatTexture();
             DefaultTextureInfoModel defaultTextureInfo0 =
                 (DefaultTextureInfoModel) textureInfo0;
             defaultTextureInfo0.setTextureModel(null);
@@ -288,7 +288,7 @@ public class GltfModelTransformsTests
             DefaultMaterialsClearcoatModel defaultClearcoat0 =
                 material0.getExtensionModel("KHR_materials_clearcoat",
                     DefaultMaterialsClearcoatModel.class);
-            defaultClearcoat0.setClearcoatTextureInfoModel(null);
+            defaultClearcoat0.setClearcoatTexture(null);
 
             GltfModelTransforms.prune(gltfModel);
 
@@ -669,7 +669,7 @@ public class GltfModelTransformsTests
             PbrMetallicRoughnessModel pbr =
                 material0.getPbrMetallicRoughnessModel();
             DefaultTextureInfoModel textureInfo =
-                (DefaultTextureInfoModel) pbr.getBaseColorTextureInfoModel();
+                (DefaultTextureInfoModel) pbr.getBaseColorTexture();
             textureInfo.removeExtensionModel("KHR_texture_transform");
         };
         return TestCase.create(name, modifiedName, gltfModel, op);
@@ -694,7 +694,7 @@ public class GltfModelTransformsTests
                 "KHR_materials_clearcoat", MaterialsClearcoatModel.class);
             DefaultTextureInfoModel textureInfo =
                 (DefaultTextureInfoModel) clearcoat
-                    .getClearcoatTextureInfoModel();
+                    .getClearcoatTexture();
             DefaultTextureTransformModel textureTransform =
                 new DefaultTextureTransformModel();
             textureTransform.setOffset(new double[]

--- a/jgltf-model-transform/src/test/java/de/javagl/jgltf/model/transform/test/GltfTestModelCreation.java
+++ b/jgltf-model-transform/src/test/java/de/javagl/jgltf/model/transform/test/GltfTestModelCreation.java
@@ -546,7 +546,7 @@ class GltfTestModelCreation
             materialModel.getPbrMetallicRoughnessModel();
         DefaultTextureInfoModel baseColorTextureInfoModel =
             (DefaultTextureInfoModel) pbrMetallicRoughnessModel
-                .getBaseColorTextureInfoModel();
+                .getBaseColorTexture();
 
         // Create the texture transform and assign it to the base color
         DefaultTextureTransformModel baseColorTextureTransform =
@@ -659,7 +659,7 @@ class GltfTestModelCreation
             new DefaultTextureInfoModel();
         baseColorTextureInfoModel.setTextureModel(baseColorTextureModel);
         pbrMetallicRoughnessModel
-            .setBaseColorTextureInfoModel(baseColorTextureInfoModel);
+            .setBaseColorTexture(baseColorTextureInfoModel);
         materialModel.setPbrMetallicRoughnessModel(pbrMetallicRoughnessModel);
 
         // Assign the emissive texture to the material
@@ -668,7 +668,7 @@ class GltfTestModelCreation
         DefaultTextureModel emissiveTextureModel =
             createSimpleTextureModel("emissive.png", Color.WHITE, Color.BLACK);
         emissiveTextureInfoModel.setTextureModel(emissiveTextureModel);
-        materialModel.setEmissiveTextureInfoModel(emissiveTextureInfoModel);
+        materialModel.setEmissiveTexture(emissiveTextureInfoModel);
 
         meshPrimitiveModel.setMaterialModel(materialModel);
 
@@ -2505,7 +2505,7 @@ class GltfTestModelCreation
         DefaultTextureModel textureModel = createSimpleTextureModel(uri);
         baseColorTextureInfoModel.setTextureModel(textureModel);
         pbrMetallicRoughnessModel
-            .setBaseColorTextureInfoModel(baseColorTextureInfoModel);
+            .setBaseColorTexture(baseColorTextureInfoModel);
 
         materialModel.setPbrMetallicRoughnessModel(pbrMetallicRoughnessModel);
         materialModel.setDoubleSided(true);
@@ -2554,7 +2554,7 @@ class GltfTestModelCreation
         DefaultTextureInfoModel clearcoatTextureInfoModel =
             new DefaultTextureInfoModel();
         clearcoatTextureInfoModel.setTextureModel(textureModel);
-        clearcoatModel.setClearcoatTextureInfoModel(clearcoatTextureInfoModel);
+        clearcoatModel.setClearcoatTexture(clearcoatTextureInfoModel);
         clearcoatModel.setClearcoatFactor(1.0);
 
         materialModel.addExtensionModel("KHR_materials_clearcoat",

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/PbrMaterialModel.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/PbrMaterialModel.java
@@ -61,11 +61,11 @@ public interface PbrMaterialModel extends MaterialModel
     PbrMetallicRoughnessModel getPbrMetallicRoughnessModel();
 
     /**
-     * Returns the base color {@link TextureModel}
+     * Returns the base color {@link TextureModel} (optional)
      * 
      * @return The {@link TextureModel}
      */
-    default TextureModel getBaseColorTexture()
+    default TextureModel getBaseColorTextureModel()
     {
         PbrMetallicRoughnessModel pbrMetallicRoughnessModel =
             getPbrMetallicRoughnessModel();
@@ -74,7 +74,7 @@ public interface PbrMaterialModel extends MaterialModel
             return null;
         }
         TextureInfoModel textureInfo =
-            pbrMetallicRoughnessModel.getBaseColorTextureInfoModel();
+            pbrMetallicRoughnessModel.getBaseColorTexture();
         if (textureInfo == null)
         {
             return null;
@@ -83,7 +83,7 @@ public interface PbrMaterialModel extends MaterialModel
     }
 
     /**
-     * Returns the base color texture coordinate index
+     * Returns the base color texture coordinate index (optional)
      * 
      * @return The index
      */
@@ -96,7 +96,7 @@ public interface PbrMaterialModel extends MaterialModel
             return null;
         }
         TextureInfoModel textureInfo =
-            pbrMetallicRoughnessModel.getBaseColorTextureInfoModel();
+            pbrMetallicRoughnessModel.getBaseColorTexture();
         if (textureInfo == null)
         {
             return null;
@@ -105,11 +105,11 @@ public interface PbrMaterialModel extends MaterialModel
     }
 
     /**
-     * Returns the metallic-roughness {@link TextureModel}
+     * Returns the metallic-roughness {@link TextureModel} (optional)
      * 
      * @return The {@link TextureModel}
      */
-    default TextureModel getMetallicRoughnessTexture()
+    default TextureModel getMetallicRoughnessTextureModel()
     {
         PbrMetallicRoughnessModel pbrMetallicRoughnessModel =
             getPbrMetallicRoughnessModel();
@@ -118,7 +118,7 @@ public interface PbrMaterialModel extends MaterialModel
             return null;
         }
         TextureInfoModel textureInfo =
-            pbrMetallicRoughnessModel.getMetallicRoughnessTextureInfoModel();
+            pbrMetallicRoughnessModel.getMetallicRoughnessTexture();
         if (textureInfo == null)
         {
             return null;
@@ -127,7 +127,7 @@ public interface PbrMaterialModel extends MaterialModel
     }
     
     /**
-     * Returns the metallic-roughness texture coordinate index
+     * Returns the metallic-roughness texture coordinate index (optional)
      * 
      * @return The index
      */
@@ -140,7 +140,7 @@ public interface PbrMaterialModel extends MaterialModel
             return null;
         }
         TextureInfoModel textureInfo =
-            pbrMetallicRoughnessModel.getMetallicRoughnessTextureInfoModel();
+            pbrMetallicRoughnessModel.getMetallicRoughnessTexture();
         if (textureInfo == null)
         {
             return null;
@@ -149,20 +149,27 @@ public interface PbrMaterialModel extends MaterialModel
     }
     
     /**
-     * Returns the {@link NormalTextureInfoModel} of this material
+     * Returns the {@link NormalTextureInfoModel} of this material (optional)
      * 
      * @return The {@link NormalTextureInfoModel}
      */
-    NormalTextureInfoModel getNormalTextureInfoModel();
+    NormalTextureInfoModel getNormalTexture();
+    
+    /**
+     * Set the {@link NormalTextureInfoModel} of this material (optional)
+     * 
+     * @param normalTexture The {@link NormalTextureInfoModel}
+     */
+    void setNormalTexture(NormalTextureInfoModel normalTexture);
 
     /**
-     * Returns the normal {@link TextureModel}
+     * Returns the normal {@link TextureModel} (optional)
      * 
      * @return The {@link TextureModel}
      */
-    default TextureModel getNormalTexture()
+    default TextureModel getNormalTextureModel()
     {
-        TextureInfoModel textureInfo = getNormalTextureInfoModel();
+        TextureInfoModel textureInfo = getNormalTexture();
         if (textureInfo == null)
         {
             return null;
@@ -171,13 +178,13 @@ public interface PbrMaterialModel extends MaterialModel
     }
     
     /**
-     * Returns the normal texture coordinate index
+     * Returns the normal texture coordinate index (optional)
      * 
      * @return The index
      */
     default Integer getNormalTexcoord()
     {
-        TextureInfoModel textureInfo = getNormalTextureInfoModel();
+        TextureInfoModel textureInfo = getNormalTexture();
         if (textureInfo == null)
         {
             return null;
@@ -186,13 +193,15 @@ public interface PbrMaterialModel extends MaterialModel
     }
     
     /**
-     * Returns the normal scale
+     * The scalar parameter applied to each normal vector of the normal 
+     * texture. (optional)<br> 
+     * Default: 1.0 
      * 
      * @return The normal scale
      */
     default Double getNormalScale()
     {
-        NormalTextureInfoModel textureInfo = getNormalTextureInfoModel();
+        NormalTextureInfoModel textureInfo = getNormalTexture();
         if (textureInfo == null)
         {
             return null;
@@ -201,20 +210,27 @@ public interface PbrMaterialModel extends MaterialModel
     }
     
     /**
-     * Returns the {@link OcclusionTextureInfoModel} of this material
+     * Returns the {@link OcclusionTextureInfoModel} of this material (optional)
      * 
      * @return The {@link OcclusionTextureInfoModel}
      */
-    OcclusionTextureInfoModel getOcclusionTextureInfoModel();
+    OcclusionTextureInfoModel getOcclusionTexture();
 
     /**
-     * Returns the occlusion {@link TextureModel}
+     * Set the {@link OcclusionTextureInfoModel} of this material (optional)
+     * 
+     * @param occlusionTexture The {@link OcclusionTextureInfoModel}
+     */
+    void setOcclusionTexture(OcclusionTextureInfoModel occlusionTexture);
+    
+    /**
+     * Returns the occlusion {@link TextureModel} (optional)
      * 
      * @return The {@link TextureModel}
      */
-    default TextureModel getOcclusionTexture()
+    default TextureModel getOcclusionTextureModel()
     {
-        TextureInfoModel textureInfo = getOcclusionTextureInfoModel();
+        TextureInfoModel textureInfo = getOcclusionTexture();
         if (textureInfo == null)
         {
             return null;
@@ -223,13 +239,13 @@ public interface PbrMaterialModel extends MaterialModel
     }
     
     /**
-     * Returns the occlusion texture coordinate index
+     * Returns the occlusion texture coordinate index (optional)
      * 
      * @return The index
      */
     default Integer getOcclusionTexcoord()
     {
-        TextureInfoModel textureInfo = getOcclusionTextureInfoModel();
+        TextureInfoModel textureInfo = getOcclusionTexture();
         if (textureInfo == null)
         {
             return null;
@@ -238,13 +254,17 @@ public interface PbrMaterialModel extends MaterialModel
     }
     
     /**
-     * Returns the occlusion strength
+     * A scalar multiplier controlling the amount of occlusion applied. 
+     * (optional)<br> 
+     * Default: 1.0<br> 
+     * Minimum: 0.0 (inclusive)<br> 
+     * Maximum: 1.0 (inclusive) 
      * 
      * @return The occlusion strength
      */
     default Double getOcclusionStrength()
     {
-        OcclusionTextureInfoModel textureInfo = getOcclusionTextureInfoModel();
+        OcclusionTextureInfoModel textureInfo = getOcclusionTexture();
         if (textureInfo == null)
         {
             return null;
@@ -253,20 +273,27 @@ public interface PbrMaterialModel extends MaterialModel
     }
     
     /**
-     * Returns the {@link TextureInfoModel} for the emissive texture
+     * Returns the {@link TextureInfoModel} for the emissive texture (optional)
      * 
      * @return The {@link TextureInfoModel}
      */
-    TextureInfoModel getEmissiveTextureInfoModel();
+    TextureInfoModel getEmissiveTexture();
 
     /**
-     * Returns the emissive {@link TextureModel}
+     * Set the {@link TextureInfoModel} for the emissive texture (optional)
+     * 
+     * @param emissiveTexture The {@link TextureInfoModel}
+     */
+    void setEmissiveTexture(TextureInfoModel emissiveTexture);
+
+    /**
+     * Returns the emissive {@link TextureModel} (optional)
      * 
      * @return The {@link TextureModel}
      */
-    default TextureModel getEmissiveTexture()
+    default TextureModel getEmissiveTextureModel()
     {
-        TextureInfoModel textureInfo = getEmissiveTextureInfoModel();
+        TextureInfoModel textureInfo = getEmissiveTexture();
         if (textureInfo == null)
         {
             return null;
@@ -275,13 +302,13 @@ public interface PbrMaterialModel extends MaterialModel
     }
     
     /**
-     * Returns the emissive texture coordinate index
+     * Returns the emissive texture coordinate index (optional)
      * 
      * @return The index
      */
     default Integer getEmissiveTexcoord()
     {
-        TextureInfoModel textureInfo = getEmissiveTextureInfoModel();
+        TextureInfoModel textureInfo = getEmissiveTexture();
         if (textureInfo == null)
         {
             return null;
@@ -290,31 +317,82 @@ public interface PbrMaterialModel extends MaterialModel
     }
     
     /**
-     * Returns the emissive factor
+     * The factors for the emissive color of the material. (optional)<br> 
+     * Default: [0.0,0.0,0.0]<br> 
+     * Number of items: 3<br> 
+     * Array elements:<br> 
+     * &nbsp;&nbsp;The elements of this array (optional)<br> 
+     * &nbsp;&nbsp;Minimum: 0.0 (inclusive)<br> 
+     * &nbsp;&nbsp;Maximum: 1.0 (inclusive) 
      * 
-     * @return The emissive factor
+     * @return emissiveFactor The emissiveFactor
      */
     double[] getEmissiveFactor();
 
     /**
-     * Returns the alpha mode
+     * The factors for the emissive color of the material. (optional)<br> 
+     * Default: [0.0,0.0,0.0]<br> 
+     * Number of items: 3<br> 
+     * Array elements:<br> 
+     * &nbsp;&nbsp;The elements of this array (optional)<br> 
+     * &nbsp;&nbsp;Minimum: 0.0 (inclusive)<br> 
+     * &nbsp;&nbsp;Maximum: 1.0 (inclusive) 
+     * 
+     * @param emissiveFactor The emissiveFactor to set
+     */
+    void setEmissiveFactor(double emissiveFactor[]);
+
+    /**
+     * The alpha rendering mode of the material. (optional)<br> 
+     * Default: "OPAQUE"<br> 
+     * Valid values: [OPAQUE, MASK, BLEND] 
      * 
      * @return The alpha mode
      */
     AlphaMode getAlphaMode();
 
     /**
-     * Returns the alpha cutoff
+     * The alpha rendering mode of the material. (optional)<br> 
+     * Default: "OPAQUE"<br> 
+     * Valid values: [OPAQUE, MASK, BLEND] 
+     * 
+     * @param alphaMode The alpha mode
+     */
+    void setAlphaMode(AlphaMode alphaMode);
+    
+
+    /**
+     * The alpha cutoff value of the material. (optional)<br> 
+     * Default: 0.5<br> 
+     * Minimum: 0.0 (inclusive) 
      * 
      * @return The alpha cutoff
      */
     Double getAlphaCutoff();
+    
+    /**
+     * The alpha cutoff value of the material. (optional)<br> 
+     * Default: 0.5<br> 
+     * Minimum: 0.0 (inclusive) 
+     * 
+     * @param alphaCutoff The alpha cutoff
+     */
+    void setAlphaCutoff(Double alphaCutoff);
 
     /**
-     * Returns whether the material is double sided
+     * Specifies whether the material is double sided. (optional)<br> 
+     * Default: false 
      *
      * @return Whether the material is double sided
      */
     Boolean isDoubleSided();
+    
+    /**
+     * Specifies whether the material is double sided. (optional)<br> 
+     * Default: false 
+     * 
+     * @param doubleSided Whether the material is double sided
+     */
+    void setDoubleSided(Boolean doubleSided);
     
 }

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/PbrMetallicRoughnessModel.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/PbrMetallicRoughnessModel.java
@@ -33,38 +33,98 @@ package de.javagl.jgltf.model;
 public interface PbrMetallicRoughnessModel extends ModelElement
 {
     /**
-     * Returns the base color factor
+     * The factors for the base color of the material. (optional)<br> 
+     * Default: [1.0,1.0,1.0,1.0]<br> 
+     * Number of items: 4<br> 
+     * Array elements:<br> 
+     * &nbsp;&nbsp;The elements of this array (optional)<br> 
+     * &nbsp;&nbsp;Minimum: 0.0 (inclusive)<br> 
+     * &nbsp;&nbsp;Maximum: 1.0 (inclusive) 
      *
      * @return The base color factor
      */
     double[] getBaseColorFactor();
-
+    
     /**
-     * Returns the base color texture info
-     *
-     * @return The base color texture info
+     * The factors for the base color of the material. (optional)<br> 
+     * Default: [1.0,1.0,1.0,1.0]<br> 
+     * Number of items: 4<br> 
+     * Array elements:<br> 
+     * &nbsp;&nbsp;The elements of this array (optional)<br> 
+     * &nbsp;&nbsp;Minimum: 0.0 (inclusive)<br> 
+     * &nbsp;&nbsp;Maximum: 1.0 (inclusive) 
+     * 
+     * @param baseColorFactor The baseColorFactor to set
      */
-    TextureInfoModel getBaseColorTextureInfoModel();
+    void setBaseColorFactor(double[] baseColorFactor);
 
     /**
-     * Returns the metallic factor
+     * The base color texture. (optional) 
+     *
+     * @return The base color texture
+     */
+    TextureInfoModel getBaseColorTexture();
+
+    /**
+     * The base color texture. (optional) 
+     * 
+     * @param baseColorTexture The baseColorTexture to set
+     */
+    void setBaseColorTexture(TextureInfoModel baseColorTexture);
+    
+    /**
+     * The factor for the metalness of the material. (optional)<br> 
+     * Default: 1.0<br> 
+     * Minimum: 0.0 (inclusive)<br> 
+     * Maximum: 1.0 (inclusive) 
      *
      * @return The metallic factor
      */
     Double getMetallicFactor();
     
     /**
-     * Returns the roughness factor
-     *
-     * @return The roughness factor
+     * The factor for the metalness of the material. (optional)<br> 
+     * Default: 1.0<br> 
+     * Minimum: 0.0 (inclusive)<br> 
+     * Maximum: 1.0 (inclusive) 
+     * 
+     * @param metallicFactor The metallicFactor to set
+     */
+    void setMetallicFactor(Double metallicFactor);
+    
+    /**
+     * The factor for the roughness of the material. (optional)<br> 
+     * Default: 1.0<br> 
+     * Minimum: 0.0 (inclusive)<br> 
+     * Maximum: 1.0 (inclusive) 
+     * 
+     * @return roughnessFactor The roughnessFactor
      */
     Double getRoughnessFactor();
 
     /**
-     * Returns the metallic-roughness-texture info
+     * The factor for the roughness of the material. (optional)<br> 
+     * Default: 1.0<br> 
+     * Minimum: 0.0 (inclusive)<br> 
+     * Maximum: 1.0 (inclusive) 
+     * 
+     * @param roughnessFactor The roughnessFactor to set
+     */
+    void setRoughnessFactor(Double roughnessFactor);
+    
+    /**
+     * The metallic-roughness texture. (optional) 
      *
      * @return The metallic-roughness texture info
      */
-    TextureInfoModel getMetallicRoughnessTextureInfoModel();
+    TextureInfoModel getMetallicRoughnessTexture();
+    
+    /**
+     * The metallic-roughness texture. (optional) 
+     * 
+     * @param metallicRoughnessTexture The metallic-roughness texture to set
+     */
+    void setMetallicRoughnessTexture(TextureInfoModel metallicRoughnessTexture);
+    
 
 }

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/impl/DefaultPbrMaterialModel.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/impl/DefaultPbrMaterialModel.java
@@ -50,17 +50,17 @@ public final class DefaultPbrMaterialModel extends AbstractNamedModelElement
     /**
      * THe {@link NormalTextureInfoModel}
      */
-    private NormalTextureInfoModel normalTextureInfoModel;
+    private NormalTextureInfoModel normalTexture;
     
     /**
      * The {@link OcclusionTextureInfoModel}
      */
-    private OcclusionTextureInfoModel occlusionTextureInfoModel;
+    private OcclusionTextureInfoModel occlusionTexture;
     
     /**
      * The emissive {@link TextureInfoModel}
      */
-    private TextureInfoModel emissiveTextureInfoModel;
+    private TextureInfoModel emissiveTexture;
     
     /**
      * The emissive factor
@@ -88,9 +88,9 @@ public final class DefaultPbrMaterialModel extends AbstractNamedModelElement
     public DefaultPbrMaterialModel()
     {
         pbrMetallicRoughnessModel = null;
-        normalTextureInfoModel = null;
-        occlusionTextureInfoModel = null;
-        emissiveTextureInfoModel = null;
+        normalTexture = null;
+        occlusionTexture = null;
+        emissiveTexture = null;
         emissiveFactor = null;
         alphaMode = null;
         alphaCutoff = null;
@@ -115,53 +115,42 @@ public final class DefaultPbrMaterialModel extends AbstractNamedModelElement
     }
 
     @Override
-    public NormalTextureInfoModel getNormalTextureInfoModel()
+    public NormalTextureInfoModel getNormalTexture()
     {
-        return normalTextureInfoModel;
+        return normalTexture;
     }
     
-    /**
-     * Set the {@link NormalTextureInfoModel}
-     * @param normalTextureInfoModel The {@link NormalTextureInfoModel}
-     */
+    @Override
     public void
-        setNormalTextureInfoModel(NormalTextureInfoModel normalTextureInfoModel)
+        setNormalTexture(NormalTextureInfoModel normalTexture)
     {
-        this.normalTextureInfoModel = normalTextureInfoModel;
+        this.normalTexture = normalTexture;
     }
 
     @Override
-    public OcclusionTextureInfoModel getOcclusionTextureInfoModel()
+    public OcclusionTextureInfoModel getOcclusionTexture()
     {
-        return occlusionTextureInfoModel;
+        return occlusionTexture;
     }
     
-    /**
-     * Set the {@link OcclusionTextureInfoModel}
-     * 
-     * @param occlusionTextureInfoModel The {@link OcclusionTextureInfoModel}
-     */
-    public void setOcclusionTextureInfoModel(
-        OcclusionTextureInfoModel occlusionTextureInfoModel)
+    @Override
+    public void setOcclusionTexture(
+        OcclusionTextureInfoModel occlusionTexture)
     {
-        this.occlusionTextureInfoModel = occlusionTextureInfoModel;
+        this.occlusionTexture = occlusionTexture;
     }
 
     @Override
-    public TextureInfoModel getEmissiveTextureInfoModel()
+    public TextureInfoModel getEmissiveTexture()
     {
-        return emissiveTextureInfoModel;
+        return emissiveTexture;
     }
     
-    /**
-     * Set the emissive {@link TextureInfoModel}
-     * 
-     * @param emissiveTextureInfoModel The {@link TextureInfoModel}
-     */
+    @Override
     public void
-        setEmissiveTextureInfoModel(TextureInfoModel emissiveTextureInfoModel)
+        setEmissiveTexture(TextureInfoModel emissiveTexture)
     {
-        this.emissiveTextureInfoModel = emissiveTextureInfoModel;
+        this.emissiveTexture = emissiveTexture;
     }
 
     @Override
@@ -170,11 +159,7 @@ public final class DefaultPbrMaterialModel extends AbstractNamedModelElement
         return emissiveFactor;
     }
 
-    /**
-     * Set the emissive factor
-     *
-     * @param emissiveFactor The emissive factor
-     */
+    @Override
     public void setEmissiveFactor(double[] emissiveFactor)
     {
         this.emissiveFactor = emissiveFactor;
@@ -186,11 +171,7 @@ public final class DefaultPbrMaterialModel extends AbstractNamedModelElement
         return alphaMode;
     }
 
-    /**
-     * Set the alpha mode
-     *
-     * @param alphaMode The alpha mode
-     */
+    @Override
     public void setAlphaMode(AlphaMode alphaMode)
     {
         this.alphaMode = alphaMode;
@@ -202,11 +183,7 @@ public final class DefaultPbrMaterialModel extends AbstractNamedModelElement
         return alphaCutoff;
     }
 
-    /**
-     * Set the alpha cutoff
-     *
-     * @param alphaCutoff The alpha cutoff
-     */
+    @Override
     public void setAlphaCutoff(Double alphaCutoff)
     {
         this.alphaCutoff = alphaCutoff;
@@ -218,11 +195,7 @@ public final class DefaultPbrMaterialModel extends AbstractNamedModelElement
         return doubleSided;
     }
 
-    /**
-     * Set whether the material is double sided
-     *
-     * @param doubleSided Whether the material is double sided
-     */
+    @Override
     public void setDoubleSided(Boolean doubleSided)
     {
         this.doubleSided = doubleSided;
@@ -237,17 +210,17 @@ public final class DefaultPbrMaterialModel extends AbstractNamedModelElement
         {
             modelElements.add(pbrMetallicRoughnessModel);
         }
-        if (normalTextureInfoModel != null)
+        if (normalTexture != null)
         {
-            modelElements.add(normalTextureInfoModel);
+            modelElements.add(normalTexture);
         }
-        if (occlusionTextureInfoModel != null)
+        if (occlusionTexture != null)
         {
-            modelElements.add(occlusionTextureInfoModel);
+            modelElements.add(occlusionTexture);
         }
-        if (emissiveTextureInfoModel != null)
+        if (emissiveTexture != null)
         {
-            modelElements.add(emissiveTextureInfoModel);
+            modelElements.add(emissiveTexture);
         }
         return modelElements;
     }
@@ -261,15 +234,15 @@ public final class DefaultPbrMaterialModel extends AbstractNamedModelElement
         {
             setPbrMetallicRoughnessModel(null);
         }
-        if (modelElementsToRemove.contains(normalTextureInfoModel)) 
+        if (modelElementsToRemove.contains(normalTexture)) 
         {
-            setNormalTextureInfoModel(null);
+            setNormalTexture(null);
         }
-        if (modelElementsToRemove.contains(occlusionTextureInfoModel)) 
+        if (modelElementsToRemove.contains(occlusionTexture)) 
         {
-            setOcclusionTextureInfoModel(null);
+            setOcclusionTexture(null);
         }
-        if (modelElementsToRemove.contains(emissiveTextureInfoModel)) 
+        if (modelElementsToRemove.contains(emissiveTexture)) 
         {
             setEmissiveFactor(null);
         }

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/impl/DefaultPbrMetallicRoughnessModel.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/impl/DefaultPbrMetallicRoughnessModel.java
@@ -47,7 +47,7 @@ public class DefaultPbrMetallicRoughnessModel extends AbstractModelElement
     /**
      * The base color texture info
      */
-    private TextureInfoModel baseColorTextureInfoModel;
+    private TextureInfoModel baseColorTexture;
 
     /**
      * The metallic factor
@@ -62,7 +62,7 @@ public class DefaultPbrMetallicRoughnessModel extends AbstractModelElement
     /**
      * The metallic-roughness texture info
      */
-    private TextureInfoModel metallicRoughnessTextureInfoModel;
+    private TextureInfoModel metallicRoughnessTexture;
 
     /**
      * Creates a new instance
@@ -70,10 +70,10 @@ public class DefaultPbrMetallicRoughnessModel extends AbstractModelElement
     public DefaultPbrMetallicRoughnessModel()
     {
         baseColorFactor = null;
-        baseColorTextureInfoModel = null;
+        baseColorTexture = null;
         metallicFactor = null;
         roughnessFactor = null;
-        metallicRoughnessTextureInfoModel = null;
+        metallicRoughnessTexture = null;
     }
 
     @Override
@@ -82,31 +82,22 @@ public class DefaultPbrMetallicRoughnessModel extends AbstractModelElement
         return baseColorFactor;
     }
 
-    /**
-     * Set the base color factor
-     *
-     * @param baseColorFactor The base color factor
-     */
+    @Override
     public void setBaseColorFactor(double[] baseColorFactor)
     {
         this.baseColorFactor = baseColorFactor;
     }
 
     @Override
-    public TextureInfoModel getBaseColorTextureInfoModel()
+    public TextureInfoModel getBaseColorTexture()
     {
-        return baseColorTextureInfoModel;
+        return baseColorTexture;
     }
 
-    /**
-     * Set the base color texture info model
-     *
-     * @param baseColorTextureInfoModel The base color texture info model
-     */
-    public void setBaseColorTextureInfoModel(
-        TextureInfoModel baseColorTextureInfoModel)
+    @Override
+    public void setBaseColorTexture(TextureInfoModel baseColorTexture)
     {
-        this.baseColorTextureInfoModel = baseColorTextureInfoModel;
+        this.baseColorTexture = baseColorTexture;
     }
 
     @Override
@@ -115,11 +106,7 @@ public class DefaultPbrMetallicRoughnessModel extends AbstractModelElement
         return metallicFactor;
     }
 
-    /**
-     * Set the metallic factor
-     *
-     * @param metallicFactor The metallic factor
-     */
+    @Override
     public void setMetallicFactor(Double metallicFactor)
     {
         this.metallicFactor = metallicFactor;
@@ -131,66 +118,54 @@ public class DefaultPbrMetallicRoughnessModel extends AbstractModelElement
         return roughnessFactor;
     }
 
-    /**
-     * Set the roughness factor
-     *
-     * @param roughnessFactor The roughness factor
-     */
+    @Override
     public void setRoughnessFactor(Double roughnessFactor)
     {
         this.roughnessFactor = roughnessFactor;
     }
 
     @Override
-    public TextureInfoModel getMetallicRoughnessTextureInfoModel()
+    public TextureInfoModel getMetallicRoughnessTexture()
     {
-        return metallicRoughnessTextureInfoModel;
+        return metallicRoughnessTexture;
     }
 
-    /**
-     * Set the metallic-roughness-texture info model
-     *
-     * @param metallicRoughnessTextureInfoModel The metallic-roughness-texture
-     *        info model
-     */
-    public void setMetallicRoughnessTextureInfoModel(
-        TextureInfoModel metallicRoughnessTextureInfoModel)
+    @Override
+    public void
+        setMetallicRoughnessTexture(TextureInfoModel metallicRoughnessTexture)
     {
-        this.metallicRoughnessTextureInfoModel =
-            metallicRoughnessTextureInfoModel;
+        this.metallicRoughnessTexture = metallicRoughnessTexture;
     }
 
     @Override
     public Set<ModelElement> getReferencedModelElements()
     {
-        Set<ModelElement> modelElements = 
-            getReferencedExtensionModelElements();
-        if (baseColorTextureInfoModel != null)
+        Set<ModelElement> modelElements = getReferencedExtensionModelElements();
+        if (baseColorTexture != null)
         {
-            modelElements.add(baseColorTextureInfoModel);
+            modelElements.add(baseColorTexture);
         }
-        if (metallicRoughnessTextureInfoModel != null)
+        if (metallicRoughnessTexture != null)
         {
-            modelElements.add(metallicRoughnessTextureInfoModel);
+            modelElements.add(metallicRoughnessTexture);
         }
         return modelElements;
     }
-    
+
     @Override
     public boolean removeModelElements(
         Collection<? extends ModelElement> modelElementsToRemove)
     {
         removeExtensionModelElements(modelElementsToRemove);
-        if (modelElementsToRemove.contains(baseColorTextureInfoModel)) 
+        if (modelElementsToRemove.contains(baseColorTexture))
         {
-            setBaseColorTextureInfoModel(null);
+            setBaseColorTexture(null);
         }
-        if (modelElementsToRemove.contains(metallicRoughnessTextureInfoModel)) 
+        if (modelElementsToRemove.contains(metallicRoughnessTexture))
         {
-            setBaseColorTextureInfoModel(null);
+            setBaseColorTexture(null);
         }
         return false;
     }
-    
-    
+
 }

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/structure/GltfModelStructures.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/structure/GltfModelStructures.java
@@ -1145,25 +1145,25 @@ public class GltfModelStructures
 
         DefaultNormalTextureInfoModel sourceNormalTextureInfo =
             (DefaultNormalTextureInfoModel) sourceMaterial
-                .getNormalTextureInfoModel();
+                .getNormalTexture();
         DefaultNormalTextureInfoModel targetNormalTextureInfo =
             copyNormalTextureInfoModel(sourceNormalTextureInfo);
-        targetMaterial.setNormalTextureInfoModel(targetNormalTextureInfo);
+        targetMaterial.setNormalTexture(targetNormalTextureInfo);
 
         DefaultOcclusionTextureInfoModel sourceOcclusionTextureInfo =
             (DefaultOcclusionTextureInfoModel) sourceMaterial
-            .getOcclusionTextureInfoModel();
+            .getOcclusionTexture();
         DefaultOcclusionTextureInfoModel targetOcclusionTextureInfo =
             copyOcclusionTextureInfoModel(sourceOcclusionTextureInfo);
-        targetMaterial.setOcclusionTextureInfoModel(
+        targetMaterial.setOcclusionTexture(
             targetOcclusionTextureInfo);
 
         DefaultTextureInfoModel sourceEmissiveTextureInfo =
             (DefaultTextureInfoModel) sourceMaterial
-            .getEmissiveTextureInfoModel();
+            .getEmissiveTexture();
         DefaultTextureInfoModel targetEmissiveTextureInfo =
             copyTextureInfoModel(sourceEmissiveTextureInfo);
-        targetMaterial.setEmissiveTextureInfoModel(
+        targetMaterial.setEmissiveTexture(
             targetEmissiveTextureInfo);
 
         double emissiveFactor[] = sourceMaterial.getEmissiveFactor();
@@ -1198,10 +1198,10 @@ public class GltfModelStructures
         
         DefaultTextureInfoModel sourceBaseColorTextureInfo =
             (DefaultTextureInfoModel) sourcePbrMetallicRoughness
-            .getBaseColorTextureInfoModel();
+            .getBaseColorTexture();
         DefaultTextureInfoModel targetBaseColorTextureInfo = 
             copyTextureInfoModel(sourceBaseColorTextureInfo);
-        targetPbrMetallicRoughness.setBaseColorTextureInfoModel(
+        targetPbrMetallicRoughness.setBaseColorTexture(
             targetBaseColorTextureInfo);
         
         targetPbrMetallicRoughness.setMetallicFactor(
@@ -1211,10 +1211,10 @@ public class GltfModelStructures
         
         DefaultTextureInfoModel sourceMetallicRoughnessTextureInfo =
             (DefaultTextureInfoModel) sourcePbrMetallicRoughness
-            .getMetallicRoughnessTextureInfoModel();
+            .getMetallicRoughnessTexture();
         DefaultTextureInfoModel targetMetallicRoughnessTextureInfo =
             copyTextureInfoModel(sourceMetallicRoughnessTextureInfo);
-        targetPbrMetallicRoughness.setMetallicRoughnessTextureInfoModel(
+        targetPbrMetallicRoughness.setMetallicRoughnessTexture(
             targetMetallicRoughnessTextureInfo);
         
         copyGltfPropertyElements(

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfCreatorV2.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfCreatorV2.java
@@ -746,7 +746,7 @@ public class GltfCreatorV2
         }
             
         NormalTextureInfoModel normalTextureInfoModel = 
-            materialModel.getNormalTextureInfoModel();
+            materialModel.getNormalTexture();
         if (normalTextureInfoModel != null)
         {
             MaterialNormalTextureInfo normalTextureInfo = 
@@ -755,7 +755,7 @@ public class GltfCreatorV2
         }
 
         OcclusionTextureInfoModel occlusionTextureInfoModel = 
-            materialModel.getOcclusionTextureInfoModel();
+            materialModel.getOcclusionTexture();
         if (occlusionTextureInfoModel != null)
         {
             
@@ -765,7 +765,7 @@ public class GltfCreatorV2
         }
         
         TextureInfoModel emissiveTextureInfoModel = 
-            materialModel.getEmissiveTextureInfoModel();
+            materialModel.getEmissiveTexture();
         if (emissiveTextureInfoModel != null)
         {
             TextureInfo emissiveTextureInfo = 
@@ -798,7 +798,7 @@ public class GltfCreatorV2
             pbrMetallicRoughnessModel.getBaseColorFactor());
 
         TextureInfoModel baseColorTextureInfoModel =
-            pbrMetallicRoughnessModel.getBaseColorTextureInfoModel();
+            pbrMetallicRoughnessModel.getBaseColorTexture();
         if (baseColorTextureInfoModel != null)
         {
             TextureInfo baseColorTextureInfo = 
@@ -813,7 +813,7 @@ public class GltfCreatorV2
         
         TextureInfoModel metallicRoughnessTextureInfoModel =
             pbrMetallicRoughnessModel
-                .getMetallicRoughnessTextureInfoModel();
+                .getMetallicRoughnessTexture();
         if (metallicRoughnessTextureInfoModel != null)
         {
             TextureInfo metallicRoughnessTextureInfo = 

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfModelCreatorV2.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfModelCreatorV2.java
@@ -1280,20 +1280,20 @@ public class GltfModelCreatorV2
             material.getNormalTexture();
         DefaultNormalTextureInfoModel normalTextureInfoModel = 
             TextureInfoModels.from(textureModels, normalTextureInfo);
-        materialModel.setNormalTextureInfoModel(normalTextureInfoModel);
+        materialModel.setNormalTexture(normalTextureInfoModel);
 
         MaterialOcclusionTextureInfo occlusionTextureInfo = 
             material.getOcclusionTexture();
         DefaultOcclusionTextureInfoModel occlusionTextureInfoModel =
             TextureInfoModels.from(textureModels, occlusionTextureInfo);
-        materialModel.setOcclusionTextureInfoModel(
+        materialModel.setOcclusionTexture(
             occlusionTextureInfoModel);
 
         TextureInfo emissiveTextureInfo = 
             material.getEmissiveTexture();
         DefaultTextureInfoModel emissiveTextureInfoModel = 
             TextureInfoModels.from(textureModels, emissiveTextureInfo);
-        materialModel.setEmissiveTextureInfoModel(emissiveTextureInfoModel);
+        materialModel.setEmissiveTexture(emissiveTextureInfoModel);
         
         materialModel.setEmissiveFactor(
             Optionals.clone(material.getEmissiveFactor()));
@@ -1320,7 +1320,7 @@ public class GltfModelCreatorV2
             // Create the TextureInfoModel and assign it to the material model
             DefaultTextureInfoModel baseColorTextureInfoModel = 
                 new DefaultTextureInfoModel();
-            pbrMetallicRoughnessModel.setBaseColorTextureInfoModel(
+            pbrMetallicRoughnessModel.setBaseColorTexture(
                 baseColorTextureInfoModel);
 
             // Initialize the TextureInfoModel
@@ -1336,7 +1336,7 @@ public class GltfModelCreatorV2
             // Create the TextureInfoModel and assign it to the material model
             DefaultTextureInfoModel metallicRoughnessTextureInfoModel = 
                 new DefaultTextureInfoModel();
-            pbrMetallicRoughnessModel.setMetallicRoughnessTextureInfoModel(
+            pbrMetallicRoughnessModel.setMetallicRoughnessTexture(
                 metallicRoughnessTextureInfoModel);
 
             // Initialize the TextureInfoModel

--- a/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfModelExtensionProcessorV2.java
+++ b/jgltf-model/src/main/java/de/javagl/jgltf/model/v2/GltfModelExtensionProcessorV2.java
@@ -243,7 +243,7 @@ class GltfModelExtensionProcessorV2
                 PbrMetallicRoughnessModel.class);
             
             TextureInfoModel baseColorTextureInfoModel = 
-                pbrMetallicRoughnessModel.getBaseColorTextureInfoModel();
+                pbrMetallicRoughnessModel.getBaseColorTexture();
             if (baseColorTextureInfoModel != null)
             {
                 ExtensionModels.createExtensionModels(gltfModel, 
@@ -252,7 +252,7 @@ class GltfModelExtensionProcessorV2
             }
             
             TextureInfoModel metallicRoughnessTextureInfoModel =
-                pbrMetallicRoughnessModel.getMetallicRoughnessTextureInfoModel();
+                pbrMetallicRoughnessModel.getMetallicRoughnessTexture();
             if (metallicRoughnessTextureInfoModel != null)
             {
                 ExtensionModels.createExtensionModels(gltfModel, 
@@ -262,7 +262,7 @@ class GltfModelExtensionProcessorV2
         }
         
         NormalTextureInfoModel normalTextureInfoModel = 
-            pbrMaterialModel.getNormalTextureInfoModel();
+            pbrMaterialModel.getNormalTexture();
         if (normalTextureInfoModel != null)
         {
             ExtensionModels.createExtensionModels(gltfModel, 
@@ -270,7 +270,7 @@ class GltfModelExtensionProcessorV2
                 TextureInfoModel.class);
         }
         OcclusionTextureInfoModel occlusionTextureInfoModel = 
-            pbrMaterialModel.getOcclusionTextureInfoModel();
+            pbrMaterialModel.getOcclusionTexture();
         if (occlusionTextureInfoModel != null)
         {
             ExtensionModels.createExtensionModels(gltfModel, 
@@ -278,7 +278,7 @@ class GltfModelExtensionProcessorV2
                 TextureInfoModel.class);
         }
         TextureInfoModel emissiveTextureInfoModel = 
-            pbrMaterialModel.getEmissiveTextureInfoModel();
+            pbrMaterialModel.getEmissiveTexture();
         if (emissiveTextureInfoModel != null)
         {
             ExtensionModels.createExtensionModels(gltfModel, 

--- a/jgltf-obj/src/main/java/de/javagl/jgltf/obj/model/MtlMaterialHandlerV2.java
+++ b/jgltf-obj/src/main/java/de/javagl/jgltf/obj/model/MtlMaterialHandlerV2.java
@@ -130,7 +130,7 @@ class MtlMaterialHandlerV2 implements MtlMaterialHandler
         
         DefaultTextureInfoModel textureInfo = new DefaultTextureInfoModel();
         textureInfo.setTextureModel(textureModel);
-        metallicRoughness.setBaseColorTextureInfoModel(textureInfo);
+        metallicRoughness.setBaseColorTexture(textureInfo);
 
         metallicRoughness.setMetallicFactor(0.0);
         metallicRoughness.setRoughnessFactor(1.0);

--- a/jgltf-viewer/src/main/java/de/javagl/jgltf/viewer/RenderedMaterialHandler.java
+++ b/jgltf-viewer/src/main/java/de/javagl/jgltf/viewer/RenderedMaterialHandler.java
@@ -277,7 +277,7 @@ class RenderedMaterialHandler
         
         
         TextureModel baseColorTexture = 
-            material.getBaseColorTexture();
+            material.getBaseColorTextureModel();
         if (baseColorTexture != null)
         {
             values.put("hasBaseColorTexture", 1);
@@ -301,7 +301,7 @@ class RenderedMaterialHandler
         
         
         TextureModel metallicRoughnessTexture = 
-            material.getMetallicRoughnessTexture();
+            material.getMetallicRoughnessTextureModel();
         if (metallicRoughnessTexture != null)
         {
             values.put("hasMetallicRoughnessTexture", 1);
@@ -325,7 +325,7 @@ class RenderedMaterialHandler
         
         
         TextureModel normalTexture = 
-            material.getNormalTexture();
+            material.getNormalTextureModel();
         if (normalTexture != null)
         {
             values.put("hasNormalTexture", 1);
@@ -334,7 +334,7 @@ class RenderedMaterialHandler
             values.put("normalTexture", normalTexture);
             
             NormalTextureInfoModel normalTextureInfo = 
-                material.getNormalTextureInfoModel();
+                material.getNormalTexture();
             double normalScale = normalTextureInfo.getScale();
             values.put("normalScale", normalScale);
         }
@@ -345,7 +345,7 @@ class RenderedMaterialHandler
         }
 
         TextureModel occlusionTexture = 
-            material.getOcclusionTexture();
+            material.getOcclusionTextureModel();
         if (occlusionTexture != null)
         {
             values.put("hasOcclusionTexture", 1);
@@ -354,7 +354,7 @@ class RenderedMaterialHandler
             values.put("occlusionTexture", occlusionTexture);
             
             OcclusionTextureInfoModel occlusionTextureInfo = 
-                material.getOcclusionTextureInfoModel();
+                material.getOcclusionTexture();
             double occlusionStrength = occlusionTextureInfo.getStrength();
             values.put("occlusionStrength", occlusionStrength);
         }
@@ -367,7 +367,7 @@ class RenderedMaterialHandler
         }
 
         TextureModel emissiveTexture = 
-            material.getEmissiveTexture();
+            material.getEmissiveTextureModel();
         if (emissiveTexture != null)
         {
             values.put("hasEmissiveTexture", 1);


### PR DESCRIPTION
Building on top of https://github.com/javagl/JglTF/pull/154 :  

During the implementation of the PBR extensions, I stumbled over a few inconsistencies in the material implementations. Some of these points have already been brought up in the comment at https://github.com/javagl/JglTF/pull/134#issuecomment-3632126358 . They generally revolve around mutability and the question which functions are supposed to be in interfaces or default implementations. This PR is a "small" change in many ways, but "breaking" compared to the previous (draft) state:

- The `PbrMaterialModel` and related interfaces are now mutable. Previously, they only offered getters for things like the "base color factor". Now, they are also offering setters. This will reduce the necessity for casting to the `Default...` implementations. The decision here is still not absolutely final, given the considerations in the linked comment
- The functions that receive a 'texture' on a conceptual level, e.g. the 'base color texture', did actually not receive a 'texture'. Even on the level of the glTF JSON, these things are not 'textures', but 'textureInfo' objects. And given that this refers to the 'model' part of the library, I originally gave these methods elaborate names like 'setBaseColorTextureInfoModel'. For conciseness and consistency with the PBR extensions, I now renamed them to 'setBaseColorTexture'. The consensus should be that in the 'model' layer, every texture is a `TextureInfoModel` (unless it's explicitly referred to as a `TextureModel` or so...)


